### PR TITLE
영감 보기 그리드 디자인 설정

### DIFF
--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -13,8 +13,4 @@ const tagCss = css`
   font-size: 12px;
   line-height: 14px;
   flex-shrink: 0;
-
-  :not(:last-child) {
-    margin-right: 8px;
-  }
 `;

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+export default function Tag({ text }: { text: string }) {
+  return <button css={tagCss}>#{text}</button>;
+}
+
+const tagCss = css`
+  display: inline-block;
+  height: 24px;
+  border-radius: 4px;
+  background: #f7f7f7;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  flex-shrink: 0;
+
+  :not(:last-child) {
+    margin-right: 8px;
+  }
+`;

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -8,7 +8,7 @@ const tagCss = css`
   display: inline-block;
   height: 24px;
   border-radius: 4px;
-  background: #f7f7f7;
+  background: #fbfbfb;
   font-weight: 500;
   font-size: 12px;
   line-height: 14px;

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -6,11 +6,15 @@ export default function Tag({ text }: { text: string }) {
 
 const tagCss = css`
   display: inline-block;
+  flex-shrink: 0;
   height: 24px;
   border-radius: 4px;
   background: #fbfbfb;
   font-weight: 500;
   font-size: 12px;
   line-height: 14px;
-  flex-shrink: 0;
+
+  :last-child {
+    margin-right: 8px;
+  }
 `;

--- a/src/components/home/ContentHeader.tsx
+++ b/src/components/home/ContentHeader.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+export default function ContentHeader() {
+  return (
+    <div css={ContentHeaderCss}>
+      <button css={HeaderButtonCss}>태그</button>
+      <button css={HeaderButtonCss}>설정</button>
+    </div>
+  );
+}
+
+const ContentHeaderCss = css``;
+
+const HeaderButtonCss = () => css`
+  width: 32px;
+  height: 32px;
+  border: 0.5px solid #e6e6e6;
+  font-weight: 700;
+  font-size: 10px;
+`;

--- a/src/components/home/ContentHeader.tsx
+++ b/src/components/home/ContentHeader.tsx
@@ -1,28 +1,25 @@
-import { css } from '@emotion/react';
+import { css, Theme } from '@emotion/react';
 
 export default function ContentHeader() {
   return (
-    <div css={ContentHeaderCss}>
+    <header css={ContentHeaderCss}>
       <button css={HeaderButtonCss}>태그</button>
       <button css={HeaderButtonCss}>설정</button>
-    </div>
+    </header>
   );
 }
 
 const ContentHeaderCss = css`
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
   margin-bottom: 20px;
 `;
 
-const HeaderButtonCss = () => css`
+const HeaderButtonCss = (theme: Theme) => css`
   width: 32px;
   height: 32px;
-  border: 0.5px solid #e6e6e6;
+  background: ${theme.color.gray};
   font-weight: 700;
   font-size: 10px;
-
-  :not(:last-child) {
-    margin-right: 8px;
-  }
 `;

--- a/src/components/home/ContentHeader.tsx
+++ b/src/components/home/ContentHeader.tsx
@@ -9,7 +9,11 @@ export default function ContentHeader() {
   );
 }
 
-const ContentHeaderCss = css``;
+const ContentHeaderCss = css`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+`;
 
 const HeaderButtonCss = () => css`
   width: 32px;
@@ -17,4 +21,8 @@ const HeaderButtonCss = () => css`
   border: 0.5px solid #e6e6e6;
   font-weight: 700;
   font-size: 10px;
+
+  :not(:last-child) {
+    margin-right: 8px;
+  }
 `;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -4,7 +4,7 @@ import Tag from '~/components/common/Tag';
 
 export type ContentThumbnailType = 'image' | 'text' | 'link';
 
-export interface IContentThumbnailProps {
+export interface ContentThumbnailProps {
   type: ContentThumbnailType;
   tags: string[];
   text: string;
@@ -13,7 +13,7 @@ export interface IContentThumbnailProps {
 
 export default function ContentThumbnail() {
   return (
-    <div css={contentThumbnailBoxCss}>
+    <section css={contentThumbnailBoxCss}>
       <div css={contentThumbnailCss}>
         <p css={contentText}>
           콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다.
@@ -26,7 +26,7 @@ export default function ContentThumbnail() {
           <Tag text="디자인인사이트" />
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -37,24 +37,17 @@ const contentThumbnailBoxCss = (theme: Theme) => css`
   position: relative;
   width: 100%;
   height: 100%;
+  aspect-ratio: 1;
   padding: ${contentThumbnailPadding};
   padding-right: 0;
   padding-bottom: 0;
   background: ${theme.color.gray};
   border-radius: 4px;
-
-  ::after {
-    display: block;
-    content: '';
-    padding-bottom: 100%;
-  }
 `;
 
 const contentThumbnailCss = css`
-  position: absolute;
   overflow: hidden;
-
-  height: calc(100% - ${contentThumbnailPadding});
+  height: 100%;
 `;
 
 const contentText = css`
@@ -65,12 +58,12 @@ const contentText = css`
   font-size: 12px;
   line-height: 18px;
   letter-spacing: -0.01em;
-  word-wrap: break-word;
 `;
 
 const contentTagsCss = css`
   display: flex;
   align-items: center;
+  gap: 8px;
   height: ${contentTagHeight};
   overflow-x: scroll;
   -ms-overflow-style: none;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -1,0 +1,16 @@
+import { css, Theme } from '@emotion/react';
+
+export default function ContentThumbnail() {
+  return (
+    <section css={contentThumbnailCss}>
+      콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의
+      텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다.
+    </section>
+  );
+}
+
+const contentThumbnailCss = (theme: Theme) => css`
+  width: 50%;
+  background: ${theme.color.gray};
+  border-radius: 4px;
+`;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -66,9 +66,4 @@ const contentTagsCss = css`
   gap: 8px;
   height: ${contentTagHeight};
   overflow-x: scroll;
-  -ms-overflow-style: none;
-
-  ::-webkit-scrollbar {
-    display: none !important;
-  }
 `;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -21,8 +21,8 @@ export default function ContentThumbnail() {
         </p>
         <div css={contentTagsCss}>
           <Tag text="영감" />
-          <Tag text="브랜드 디자인 레퍼런스 모음집" />
           <Tag text="UX/UI" />
+          <Tag text="브랜드 디자인 레퍼런스 모음집" />
           <Tag text="디자인인사이트" />
         </div>
       </div>
@@ -37,7 +37,9 @@ const contentThumbnailBoxCss = (theme: Theme) => css`
   position: relative;
   width: 100%;
   height: 100%;
-  padding: 12px;
+  padding: ${contentThumbnailPadding};
+  padding-right: 0;
+  padding-bottom: 0;
   background: ${theme.color.gray};
   border-radius: 4px;
 
@@ -51,12 +53,14 @@ const contentThumbnailBoxCss = (theme: Theme) => css`
 const contentThumbnailCss = css`
   position: absolute;
   overflow: hidden;
-  width: calc(100% - ${contentThumbnailPadding} * 2);
-  height: calc(100% - ${contentThumbnailPadding} * 2);
+
+  height: calc(100% - ${contentThumbnailPadding});
 `;
 
 const contentText = css`
-  height: calc(100% - ${contentThumbnailPadding} * 2 - ${contentTagHeight});
+  width: calc(100% - ${contentThumbnailPadding});
+  height: calc(100% - ${contentTagHeight});
+  background: #fbfbfb;
   font-weight: 500;
   font-size: 12px;
   line-height: 18px;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -1,16 +1,77 @@
 import { css, Theme } from '@emotion/react';
 
+import Tag from '~/components/common/Tag';
+
+export type ContentThumbnailType = 'image' | 'text' | 'link';
+
+export interface IContentThumbnailProps {
+  type: ContentThumbnailType;
+  tags: string[];
+  text: string;
+  image: string;
+}
+
 export default function ContentThumbnail() {
   return (
-    <section css={contentThumbnailCss}>
-      콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의
-      텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다.
-    </section>
+    <div css={contentThumbnailBoxCss}>
+      <div css={contentThumbnailCss}>
+        <p css={contentText}>
+          콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다.
+          콘텐츠의 텍스트는 다음과 같이 삽입됩니다. 콘텐츠의 텍스트는 다음과 같이 삽입됩니다.
+        </p>
+        <div css={contentTagsCss}>
+          <Tag text="영감" />
+          <Tag text="브랜드 디자인 레퍼런스 모음집" />
+          <Tag text="UX/UI" />
+          <Tag text="디자인인사이트" />
+        </div>
+      </div>
+    </div>
   );
 }
 
-const contentThumbnailCss = (theme: Theme) => css`
-  width: 50%;
+const contentThumbnailPadding = '12px';
+const contentTagHeight = '40px';
+
+const contentThumbnailBoxCss = (theme: Theme) => css`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 12px;
   background: ${theme.color.gray};
   border-radius: 4px;
+
+  ::after {
+    display: block;
+    content: '';
+    padding-bottom: 100%;
+  }
+`;
+
+const contentThumbnailCss = css`
+  position: absolute;
+  overflow: hidden;
+  width: calc(100% - ${contentThumbnailPadding} * 2);
+  height: calc(100% - ${contentThumbnailPadding} * 2);
+`;
+
+const contentText = css`
+  height: calc(100% - ${contentThumbnailPadding} * 2 - ${contentTagHeight});
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.01em;
+  word-wrap: break-word;
+`;
+
+const contentTagsCss = css`
+  display: flex;
+  align-items: center;
+  height: ${contentTagHeight};
+  overflow-x: scroll;
+  -ms-overflow-style: none;
+
+  ::-webkit-scrollbar {
+    display: none !important;
+  }
 `;

--- a/src/components/home/ContentView.tsx
+++ b/src/components/home/ContentView.tsx
@@ -7,8 +7,20 @@ export default function ContentView() {
     <div css={ContentViewCss}>
       <ContentThumbnail />
       <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
+      <ContentThumbnail />
     </div>
   );
 }
 
-const ContentViewCss = css``;
+const ContentViewCss = css`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+`;

--- a/src/components/home/ContentView.tsx
+++ b/src/components/home/ContentView.tsx
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+import ContentThumbnail from './ContentThumbnail';
+
+export default function ContentView() {
+  return (
+    <div css={ContentViewCss}>
+      <ContentThumbnail />
+      <ContentThumbnail />
+    </div>
+  );
+}
+
+const ContentViewCss = css``;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,12 +2,14 @@ import { AppProps } from 'next/app';
 import { ThemeProvider } from '@emotion/react';
 import { RecoilRoot } from 'recoil';
 
+import GlobalStyle from '~/styles/GlobalStyle';
 import Theme from '~/styles/Theme';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <RecoilRoot>
       <ThemeProvider theme={Theme}>
+        <GlobalStyle />
         <Component {...pageProps} />
       </ThemeProvider>
     </RecoilRoot>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,4 +12,6 @@ export default function Root() {
   );
 }
 
-const pageCss = css``;
+const pageCss = css`
+  padding: 16px;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,23 +1,15 @@
-import { css, Theme } from '@emotion/react';
-import { motion } from 'framer-motion';
+import { css } from '@emotion/react';
+
+import ContentHeader from '~/components/home/ContentHeader';
+import ContentView from '~/components/home/ContentView';
 
 export default function Root() {
   return (
-    <div>
-      <h1 css={titleCss}>영감탱</h1>
-      <div css={sampleCss}></div>
-      <motion.h2 drag>드래그해보세용</motion.h2>
-    </div>
+    <article css={pageCss}>
+      <ContentHeader />
+      <ContentView />
+    </article>
   );
 }
 
-const titleCss = css`
-  color: red;
-`;
-
-const sampleCss = (theme: Theme) => css`
-  width: 100px;
-  height: 100px;
-  color: white;
-  background-color: ${theme.color.black};
-`;
+const pageCss = css``;

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -1,5 +1,7 @@
 import { css, Global, Theme } from '@emotion/react';
 
+import { resetCss } from './reset';
+
 export default function GlobalStyle() {
   return <Global styles={globalCss} />;
 }
@@ -9,154 +11,30 @@ const globalCss = (theme: Theme) => css`
 
   * {
     box-sizing: border-box;
+    word-break: keep-all;
+    word-wrap: break-word;
+    -ms-overflow-style: none;
+
+    ::-webkit-scrollbar {
+      display: none !important;
+    }
   }
 
   :root {
     color: ${theme.color.black};
-  }
 
-  body {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    body {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
 
-    .draggable {
-      -webkit-user-select: all;
-      -moz-user-select: all;
-      -ms-user-select: all;
-      user-select: all;
+      .draggable {
+        -webkit-user-select: all;
+        -moz-user-select: all;
+        -ms-user-select: all;
+        user-select: all;
+      }
     }
-  }
-`;
-
-const resetCss = `
-  html,
-  body,
-  div,
-  span,
-  applet,
-  object,
-  iframe,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p,
-  blockquote,
-  pre,
-  a,
-  abbr,
-  acronym,
-  address,
-  big,
-  cite,
-  code,
-  del,
-  dfn,
-  em,
-  img,
-  ins,
-  kbd,
-  q,
-  s,
-  samp,
-  small,
-  strike,
-  strong,
-  sub,
-  sup,
-  tt,
-  var,
-  b,
-  u,
-  i,
-  center,
-  dl,
-  dt,
-  dd,
-  ol,
-  ul,
-  li,
-  fieldset,
-  form,
-  label,
-  legend,
-  table,
-  caption,
-  tbody,
-  tfoot,
-  thead,
-  tr,
-  th,
-  td,
-  article,
-  aside,
-  canvas,
-  details,
-  embed,
-  figure,
-  figcaption,
-  footer,
-  header,
-  hgroup,
-  menu,
-  nav,
-  output,
-  ruby,
-  section,
-  summary,
-  time,
-  mark,
-  audio,
-  video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
-  }
-  article,
-  aside,
-  details,
-  figcaption,
-  figure,
-  footer,
-  header,
-  hgroup,
-  menu,
-  nav,
-  section {
-    display: block;
-  }
-  body {
-    line-height: 1;
-  }
-  ol,
-  ul {
-    list-style: none;
-  }
-  blockquote,
-  q {
-    quotes: none;
-  }
-  blockquote:before,
-  blockquote:after,
-  q:before,
-  q:after {
-    content: '';
-    content: none;
-  }
-  button {
-    border: none;
-    cursor: pointer;
-    background-color: unset;
-  }
-  table {
-    border-collapse: collapse;
-    border-spacing: 0;
   }
 `;

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -5,11 +5,158 @@ export default function GlobalStyle() {
 }
 
 const globalCss = (theme: Theme) => css`
+  ${resetCss}
+
   * {
     box-sizing: border-box;
   }
 
   :root {
     color: ${theme.color.black};
+  }
+
+  body {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    .draggable {
+      -webkit-user-select: all;
+      -moz-user-select: all;
+      -ms-user-select: all;
+      user-select: all;
+    }
+  }
+`;
+
+const resetCss = `
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+  button {
+    border: none;
+    cursor: pointer;
+    background-color: unset;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
   }
 `;

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -1,11 +1,15 @@
-import { css, Global } from '@emotion/react';
+import { css, Global, Theme } from '@emotion/react';
 
 export default function GlobalStyle() {
   return <Global styles={globalCss} />;
 }
 
-const globalCss = css`
+const globalCss = (theme: Theme) => css`
   * {
     box-sizing: border-box;
+  }
+
+  :root {
+    color: ${theme.color.black};
   }
 `;

--- a/src/styles/GlobalStyle/reset.ts
+++ b/src/styles/GlobalStyle/reset.ts
@@ -1,0 +1,130 @@
+export const resetCss = `
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+  button {
+    border: none;
+    cursor: pointer;
+    background-color: unset;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+`;

--- a/src/styles/Theme/Theme.ts
+++ b/src/styles/Theme/Theme.ts
@@ -1,6 +1,7 @@
 const theme = {
   color: {
     black: '#000000',
+    gray: '#F7F7F7',
   },
 };
 

--- a/src/styles/Theme/Theme.ts
+++ b/src/styles/Theme/Theme.ts
@@ -1,6 +1,6 @@
 const theme = {
   color: {
-    black: '#000000',
+    black: '#495057',
     gray: '#F7F7F7',
   },
 };


### PR DESCRIPTION
#31 

# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
## [design: content thumbnail 디자인 작성 및 공통컴포넌트 tag 추가](https://github.com/depromeet/11th_7team_web/commit/e7394f96cd690c829bd1fa14039c1acb80f43fee)[](https://github.com/positiveko)

아직 디자인 미완성이지만, `globalStyle`에 수정이 있어서 풀리퀘 올립니다.

- 피그마 와이어프레임 단계라 theme을 크게 수정하지는 않았어요. 나중에 디자인 컨셉 나오게 되면 다시 theme에 font-size, font-weight, color 추가해서 적용하면 될 것 같아요 :)
- <ContentThumbnail /> 반복적으로 하드 코딩 된 부분은 백엔드 분이랑 이야기 후에 목데이터로 변경해서 map 돌리는 방식으로 수정해놓겠습니다!

## [design: global styles reset 추가 및 reset 변경에 따른 디자인 세부 수정](https://github.com/depromeet/11th_7team_web/commit/0be2c43a81a58eeb064c9116b3a5749c1f91483c)
- globalStyle에 reset을 넣어놨어요. 평소에 하던 방식이긴 한데.. 다른 분들은 어떻게 하시나 궁금하네요 :) 수정 필요하다면 말씀해주세요!
  - [레퍼런스](https://meyerweb.com/eric/tools/css/reset/)
- 전체 body에 드래그 방지를 넣어놨는데, 클래스명으로 'draggable'을 주어 선택적으로 드래그하도록 했어요
- 외려 반대로 드래그 자유도를 주되 제한된 부분에서만 드래그 방지하는 방법으로 변경 해야되나 고민이 되는데 이후 디자인 보면서 수정해도 될 것 같아요.
```css
  body {
    -webkit-user-select: none;
    -moz-user-select: none;
    -ms-user-select: none;
    user-select: none;

    .draggable {
      -webkit-user-select: all;
      -moz-user-select: all;
      -ms-user-select: all;
      user-select: all;
    }
  }
```

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
<img width="442" alt="image" src="https://user-images.githubusercontent.com/69200669/163018736-4701c498-6ca5-4379-bde7-83ac7b6cce8c.png">

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
- [reset css](https://meyerweb.com/eric/tools/css/reset/)