### PR TITLE
Router Gard 만들기 #46

### DIFF
--- a/src/with/WithRouterGard.tsx
+++ b/src/with/WithRouterGard.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function WithRouterGard({ children }: Props): JSX.Element {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    authCheck(router.asPath);
+    router.events.on('routeChangeComplete', authCheck);
+
+    return () => {
+      router.events.off('routeChangeStart', hideContent);
+      router.events.off('routeChangeComplete', authCheck);
+    };
+  }, []);
+
+  const hideContent = () => {
+    router.events.on('routeChangeStart', hideContent);
+    setAuthorized(false);
+  };
+
+  const authCheck = (url: string) => {
+    const publicRoutes = ['/password', '/signup', '/login'];
+    const path = url.split('?')[0];
+
+    if (!publicRoutes.includes(path)) {
+      setAuthorized(false);
+      router.push({
+        pathname: '/login',
+        query: { returnUrl: router.asPath },
+      });
+    } else {
+      setAuthorized(true);
+    }
+  };
+
+  return authorized ? children : <></>;
+}
+
+export interface Props {
+  children: JSX.Element;
+}

--- a/src/with/WithRouterGard.tsx
+++ b/src/with/WithRouterGard.tsx
@@ -7,6 +7,7 @@ export default function WithRouterGard({ children }: Props): JSX.Element {
 
   useEffect(() => {
     authCheck(router.asPath);
+    router.events.on('routeChangeStart', hideContent);
     router.events.on('routeChangeComplete', authCheck);
 
     return () => {

--- a/src/with/WithRouterGard.tsx
+++ b/src/with/WithRouterGard.tsx
@@ -17,7 +17,6 @@ export default function WithRouterGard({ children }: Props): JSX.Element {
   }, []);
 
   const hideContent = () => {
-    router.events.on('routeChangeStart', hideContent);
     setAuthorized(false);
   };
 

--- a/src/with/WithUpdatedRouterGard.tsx
+++ b/src/with/WithUpdatedRouterGard.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function WithUpdatedRouterGard({ children }: Props): JSX.Element {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    authCheck(router.asPath);
+  }, [router.asPath]);
+
+  const authCheck = (url: string) => {
+    const publicRoutes = ['/password', '/signup', '/login'];
+    const path = url.split('?')[0];
+
+    if (!publicRoutes.includes(path)) {
+      setAuthorized(false);
+      router.push({
+        pathname: '/login',
+        query: { returnUrl: router.asPath },
+      });
+    } else {
+      setAuthorized(true);
+    }
+  };
+
+  return authorized ? children : <></>;
+}
+
+export interface Props {
+  children: JSX.Element;
+}


### PR DESCRIPTION
## ⛳️작업 내용
2가지의 방법을 작업했습니다.
- WithRouterGard
- WithUpdatedRouterGard 

1. WithRouterGard
은 팀원 분들이 말씀하신 것들 중  `routeChangeStart`, `routeChangeComplete` 즉 next/router event를 등록하여 확인할 수 있도록 HOC로 구현한 것입니다.

2. WithUpdatedRouterGard
은 기존의 사용해본적 있다고 하신 watch를 통해 router update되면 반응하게 하는 방법입니다.

두 가지 모두 실행해 본결과 동작은 동일하게 동작됩니다.
하지만 차이점이 있다면  next/router event인 만큼 부가적인 기능들이 존재합니다. router를 넘어가면서 scroll 설정 같은걸 쉽게? 할 수 있는것으로 보입니다.

**WHY `routeChangeStart`, `routeChangeComplete` 둘 다 꼭쓰는가?**
`routeChangeStart`의 경우는 아직 URL이 변경되지 않은 시점입니다. `routeChangeComplete`은 URL이 변경되었음을 의미하지만 이 타이밍이 꼭 mounted전임을 보장하지 않습니다. 그렇기에 `routeChangeComplete`만 사용할 경우 내부라우팅 이동의 경우 컴포넌트의 mounted가 실행한 것을 테스트 했습니다. 그래서 `routeChangeStart` 인증 안되있음 살짝 쿵 가려주고 가야됩니다. 
정확하지 않지만 내부 코드를 확인 결과 그냥 url에 대한 state들이 변경되면 불리는 정도로 구현된 것으로 보입니다.


- 먼저 app에 쓰는 것보다는 HOC를 사용하는게 좋다고 생각했습니다! 어떻게 생각하시는지 궁금합니다.
- HOC 같은 경우는 with를 붙이는데 린트 걸려서 대문자 With로 했습니다. 
- 나름 두가지 방법을 구현했지만 더있다면 알려주세요! 없다면 둘 중 뭐가 더 좋을까요?

## 📸스크린샷
## ⚡️사용 방법
```
//..._app.tsx
 <WithRouterGard>
   <Component {...pageProps} />
 </WithRouterGard>
```
```
..._app.tsx
 <WithUpdatedRouterGard>
   <Component {...pageProps} />
 </WithUpdatedRouterGard>
```

## 📎레퍼런스
- https://colossal-adasaurus-103.notion.site/Router-Gard-5d9e6d09f7ed436db807f18c6c4bcd45 (개발 과정)
- https://jasonwatmore.com/post/2021/08/30/next-js-redirect-to-login-page-if-unauthenticated (대박 참고)

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
