### PR TITLE
app to web 테스트용 웹 사이트 개발 - useAppMessage 훅 개발

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -1,0 +1,7 @@
+export declare global {
+  interface Window {
+    ReactNativeWebView: {
+      postMessage(msg: string): void;
+    };
+  }
+}

--- a/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
+++ b/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren, useEffect } from 'react';
+
+import { useAppMessage } from './useAppMessage';
+
+export function AppMessageListener({ children }: PropsWithChildren<unknown>) {
+  const { startListening, stopListening } = useAppMessage();
+
+  useEffect(() => {
+    if (startListening) {
+      startListening();
+      return () => {
+        stopListening();
+      };
+    }
+  }, [startListening, stopListening]);
+
+  return <>{children}</>;
+}

--- a/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
+++ b/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren, useEffect } from 'react';
 
-import { useAppMessage } from './useAppMessage';
+import { AppMessageArgs, useAppMessage } from './useAppMessage';
 
-export function AppMessageListener({ children }: PropsWithChildren<unknown>) {
-  const { startListening, stopListening } = useAppMessage();
+export function AppMessageListener({ children, handler }: PropsWithChildren<AppMessageArgs>) {
+  const { startListening, stopListening } = useAppMessage({ handler });
 
   useEffect(() => {
     if (startListening) {

--- a/src/hooks/bridge/useAppMessage/index.ts
+++ b/src/hooks/bridge/useAppMessage/index.ts
@@ -1,0 +1,1 @@
+export { AppMessageListener } from './AppMessageListener';

--- a/src/hooks/bridge/useAppMessage/index.ts
+++ b/src/hooks/bridge/useAppMessage/index.ts
@@ -1,1 +1,3 @@
 export { AppMessageListener } from './AppMessageListener';
+export type { AppMessageData } from './useAppMessage';
+export { useAppMessage } from './useAppMessage';

--- a/src/hooks/bridge/useAppMessage/useAppMessage.ts
+++ b/src/hooks/bridge/useAppMessage/useAppMessage.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+
+type MessageAction = 'TestAction';
+
+interface MessageData {
+  action: MessageAction;
+  data: any;
+}
+
+export function useAppMessage() {
+  const listener = useCallback(({ data: rawData }: MessageEvent) => {
+    const { action, data } = JSON.parse(rawData) as MessageData;
+    switch (action) {
+      case 'TestAction':
+        console.log('[TEST] TestAction을 받았어요!!');
+        console.log('data: ', data);
+        break;
+      default:
+        throw Error('정의되지 않은 action 입니다.');
+    }
+  }, []);
+
+  const startListening = () => {
+    if (window.ReactNativeWebView) {
+      // TODO: MessageEvent 타입 호환 안되는 문제 찾아보기
+      document.addEventListener('message', listener as ({}: Event) => {}); // android
+      window.addEventListener('message', listener); // ios
+    }
+  };
+
+  const stopListening = () => {
+    if (window.ReactNativeWebView) {
+      // TODO: MessageEvent 타입 호환 안되는 문제 찾아보기
+      document.removeEventListener('message', listener as ({}: Event) => {}); // android
+      window.removeEventListener('message', listener); // ios
+    }
+  };
+
+  return {
+    startListening,
+    stopListening,
+  };
+}

--- a/src/hooks/bridge/useAppMessage/useAppMessage.ts
+++ b/src/hooks/bridge/useAppMessage/useAppMessage.ts
@@ -2,14 +2,14 @@ import { useCallback } from 'react';
 
 type MessageAction = 'TestAction';
 
-interface MessageData {
+export interface AppMessageData {
   action: MessageAction;
   data: any;
 }
 
 export function useAppMessage() {
   const listener = useCallback(({ data: rawData }: MessageEvent) => {
-    const { action, data } = JSON.parse(rawData) as MessageData;
+    const { action, data } = JSON.parse(rawData) as AppMessageData;
     switch (action) {
       case 'TestAction':
         console.log('[TEST] TestAction을 받았어요!!');

--- a/src/hooks/bridge/useAppMessage/useAppMessage.ts
+++ b/src/hooks/bridge/useAppMessage/useAppMessage.ts
@@ -1,24 +1,24 @@
 import { useCallback } from 'react';
 
-type MessageAction = 'TestAction';
-
 export interface AppMessageData {
-  action: MessageAction;
+  action: string;
   data: any;
 }
 
-export function useAppMessage() {
-  const listener = useCallback(({ data: rawData }: MessageEvent) => {
-    const { action, data } = JSON.parse(rawData) as AppMessageData;
-    switch (action) {
-      case 'TestAction':
-        console.log('[TEST] TestAction을 받았어요!!');
-        console.log('data: ', data);
-        break;
-      default:
-        throw Error('정의되지 않은 action 입니다.');
-    }
-  }, []);
+export interface AppMessageArgs {
+  handler: (action: string, data?: any) => void;
+}
+
+export function useAppMessage({ handler }: AppMessageArgs) {
+  const listener = useCallback(
+    ({ data: rawData }: MessageEvent) => {
+      if (handler) {
+        const { action, data } = JSON.parse(rawData) as AppMessageData;
+        handler(action, data);
+      }
+    },
+    [handler]
+  );
 
   const startListening = () => {
     if (window.ReactNativeWebView) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["@emotion/react/types/css-prop"]
+    "types": ["@emotion/react/types/css-prop"],
+    "typeRoots": ["@types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
> 이슈 브랜치 이름이 `issue/50` 으로 되어 있는데, 훅 제작은 분기를 해야할 것 같아서 분리하였어요!
> 실제 이슈는 #52 입니다!!

## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- [EditorConfig](https://editorconfig.org/) 파일 추가
- bridge 폴더 아래에 훅들 추가 ***<< bridge 폴더 명이 애매할 수도 있을 것 같아서 제안해주시면 좋을 것 같아요~!!***
- 메인 message 핸들링 담당하는 `useAppMessage` 추가
- useAppMessage을 담당하는 AppMessageListener 컴포넌트 생성

useAppMessage를 어디서 사용해야할지 고민이긴 한데... 생각해 본 방법은 다음과 같아요

1. 전역 _app.tsx에서 핸들링 후 store를 사용하여 각 페이지로 데이터 보내기
2. 각 페이지에서 AppMessage 리스닝 후 처리 (useAppMessage에 actions을 주입하는 방향으로 가면 좋을듯) (이거 생각중이긴 해요)

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->