### PR TITLE
Framer motion 상수 설정

### DIFF
--- a/src/constants/motions.ts
+++ b/src/constants/motions.ts
@@ -1,0 +1,32 @@
+import { Variants } from 'framer-motion';
+
+const defaultEasing = [0.6, -0.05, 0.01, 0.99];
+
+export const staggerOne: Variants = {
+  animate: { transition: { staggerChildren: 0.1 } },
+};
+
+export const staggerHalf: Variants = {
+  animate: { transition: { staggerChildren: 0.05 } },
+};
+
+export const defaultFadeInUpVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: 30,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  exit: {
+    opacity: 0,
+    y: 30,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+};


### PR DESCRIPTION
## ⛳️작업 내용

`framer-motion` 사용 시 제가 사용하던 상수들을 예제로써 적용해보았어요.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

```tsx
import { defaultFadeInUpVariants } from "~/constants/motions";

<motion.div
      initial="initial"
      animate="animate"
      exit="exit"
      variants={defaultFadeInUpVariants}
    >
</motion.div>
```

애니메이션에 대한 상수 값들이 컴포넌트에 위치하는 경우, 가독성을 떨어트릴 수도 있다고 생각해서 작업내용처럼 상수들을 모아서 관리하고 위 방법처럼 import하여 사용하곤 했어요!

`staggerOne`, `staggerHalf`의 경우 [해당 예제](https://codesandbox.io/s/framer-motion-side-menu-mx2rw?from-embed)처럼 각 child들의 애니메이션에 딜레이를 줄 때 사용해서 추가해보았어요!

사용하지 않는 방향이 된다면 추후 지워보면 될 거 같아용


## 📎레퍼런스

- [framer motion 공식 문서](https://www.framer.com/docs/)
- [framer motion staggerChildren](https://www.framer.com/docs/transition/###staggerchildren)
- [framer motion staggerChildren Example](https://codesandbox.io/s/framer-motion-side-menu-mx2rw?from-embed)


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
