### PR TITLE
모달 관련 컴포넌트 및 훅 개발

### DIFF
--- a/src/components/common/ModalWrapper.tsx
+++ b/src/components/common/ModalWrapper.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from 'react';
+import { AnimatePresence } from 'framer-motion';
+import { createPortal } from 'react-dom';
+
+interface ModalWrapperProps {
+  isShowing: boolean;
+}
+
+export default function ModalWrapper({
+  children,
+  isShowing,
+}: PropsWithChildren<ModalWrapperProps>) {
+  const container = typeof window !== 'undefined' && document.body;
+
+  return container ? (
+    createPortal(
+      <AnimatePresence exitBeforeEnter>{isShowing && children}</AnimatePresence>,
+      container
+    )
+  ) : (
+    <></>
+  );
+}

--- a/src/components/common/PortalWrapper.tsx
+++ b/src/components/common/PortalWrapper.tsx
@@ -6,7 +6,7 @@ interface ModalWrapperProps {
   isShowing: boolean;
 }
 
-export default function ModalWrapper({
+export default function PortalWrapper({
   children,
   isShowing,
 }: PropsWithChildren<ModalWrapperProps>) {

--- a/src/hooks/common/useToggle.ts
+++ b/src/hooks/common/useToggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react';
+
+export default function useToggle(defaultValue: boolean) {
+  const [value, setValue] = useState<boolean>(defaultValue);
+  const toggle = useCallback(() => {
+    setValue(prev => !prev);
+  }, []);
+
+  const result: [boolean, VoidFunction] = [value, toggle];
+  return result;
+}

--- a/src/hooks/common/useToggle.ts
+++ b/src/hooks/common/useToggle.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from 'react';
 
-export default function useToggle(defaultValue: boolean) {
+export default function useToggle(defaultValue: boolean): [boolean, VoidFunction] {
   const [value, setValue] = useState<boolean>(defaultValue);
   const toggle = useCallback(() => {
     setValue(prev => !prev);
   }, []);
 
-  const result: [boolean, VoidFunction] = [value, toggle];
-  return result;
+  return [value, toggle];
 }


### PR DESCRIPTION
## ⛳️작업 내용

모달 사용 시, `Wrapper`로써 portal 컴포넌트를 개발했어요.

추가적으로 `Wrapper` 컴포넌트에 `isShowing`이라는 이름으로 렌더링 여부를 결정했기 때문에,
`useModal`이라는 이름의 hook 보다는 `useToggle` 형태로 조금 더 범용적으로 쓰일 수 있도록 개발해보았어요.

> 추가적으로 `AnimatePresence` 컴포넌트를 사용해서 `framer`를 사용한 modal이 `exit`할 때도 애니메이션이 재생될 수 있도록 개발했어요.

## 📸스크린샷

![화면 기록 2022-04-21 오전 12 45 12](https://user-images.githubusercontent.com/26461307/164272155-693db4b3-1976-4033-a9c8-b841ef89d19b.gif)

## ⚡️사용 방법

- ### ModalWrapper

```tsx
import ModalWrapper from '~/components/common/ModalWrapper';

<ModalWrapper isShowing={어떤state}>
  <어떤모달컴포넌트라던가JSX />
</ModalWrapper>
```

- ### useToggle

```tsx
import useToggle from '~/hooks/common/useToggle';

// const [상태, 토글함수] = useToggle(초기값);
const [isShowing, toggleIsShowing] = useToggle(false);
```

- ### 합쳐서

```tsx
import ModalWrapper from '~/components/common/ModalWrapper';
import useToggle from '~/hooks/common/useToggle';

function Test() {
  const [isShowing, toggleIsShowing] = useToggle(false);

  return (
    <article>
      <ModalWrapper isShowing={isShowing}>
        <motion.div
          initial="initial"
          animate="animate"
          exit="exit"
          variants={defaultFadeInUpVariants}
        ></motion.div>
      </ModalWrapper>

      <button onClick={toggleIsShowing}>toggle</button>
    </article>
  );

}

```

## 📎레퍼런스

- [react portal](https://ko.reactjs.org/docs/portals.html)
- [Framer-motion AnimatePresence](https://www.framer.com/docs/animate-presence/)

저는 이렇게 사용하곤 했는데, 다른 방법이 있다면 공유해주세요 !! 좋은 방법이 있다면 갈아 엎어도 상관없어요!!

추가적으로 portal의 container로써 `position: absoulte 혹은 fixed`인 요소를 사용할까 고민돼요...!

현재 상태에서는 absoulte나 fixed를 `ModalWrapper`안 객체에 직접적으로 작성해주어야하기 때문입니당

container에 스타일을 적용하면 조금 더 DRY 할 수 있지 않을까? 싶은데 

각각의 모달의 자유도가 떨어질 수도 있을 것 같다 ...? 라는 생각이랄까요 ...

> 물론 사용해보고 불편하면 추가해도 좋아요!!



<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
