### PR TITLE
Pretendard 폰트 적용

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,13 @@ import { Head, Html, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html>
-      <Head></Head>
+      <Head>
+        <link
+          rel="stylesheet"
+          as="style"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -9,19 +9,11 @@ export default function GlobalStyle() {
 const globalCss = (theme: Theme) => css`
   ${resetCss}
 
-  * {
-    box-sizing: border-box;
-    word-break: keep-all;
-    word-wrap: break-word;
-    -ms-overflow-style: none;
-
-    ::-webkit-scrollbar {
-      display: none !important;
-    }
-  }
-
   :root {
     color: ${theme.color.black};
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue',
+      'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
+      'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
 
     body {
       -webkit-user-select: none;
@@ -34,6 +26,18 @@ const globalCss = (theme: Theme) => css`
         -moz-user-select: all;
         -ms-user-select: all;
         user-select: all;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: inherit;
+      word-break: keep-all;
+      word-wrap: break-word;
+      -ms-overflow-style: none;
+
+      ::-webkit-scrollbar {
+        display: none !important;
       }
     }
   }

--- a/src/styles/GlobalStyle/reset.ts
+++ b/src/styles/GlobalStyle/reset.ts
@@ -84,7 +84,6 @@ export const resetCss = `
     padding: 0;
     border: 0;
     font-size: 100%;
-    font: inherit;
     vertical-align: baseline;
   }
   article,


### PR DESCRIPTION
## ⛳️작업 내용

`_document`에 `link` 태그를 이용해 `Pretendard` 폰트를 적용했어용

css `:root`에 `font-family` 설정 하였으나, `reset`에서 여러 태그들의 font-family를 inherit으로 설정하지 않고 있어 `*` 선택자에 추가하였슴니당

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

저는 기존에 `html link`보다는 `css @import`를 이용해서 사용하곤 했는데,
이번에 궁금해서 성능적으로 어떤 것이 우위에 있을 지 궁금해서 찾아봤어요!

> 유의미하진 않지만, `html link`가 이점이 있다고 합니다 ...!

- [Best way to add a custom font to my site?](https://webmasters.stackexchange.com/questions/108916/best-way-to-add-a-custom-font-to-my-site)
- [dont use @import](https://www.stevesouders.com/blog/2009/04/09/dont-use-import/)

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
