### PR TITLE
emotion color palette 설정

### DIFF
--- a/src/components/home/ContentHeader.tsx
+++ b/src/components/home/ContentHeader.tsx
@@ -19,7 +19,7 @@ const ContentHeaderCss = css`
 const HeaderButtonCss = (theme: Theme) => css`
   width: 32px;
   height: 32px;
-  background: ${theme.color.gray};
+  background: ${theme.color.background};
   font-weight: 700;
   font-size: 10px;
 `;

--- a/src/components/home/ContentThumbnail.tsx
+++ b/src/components/home/ContentThumbnail.tsx
@@ -41,7 +41,7 @@ const contentThumbnailBoxCss = (theme: Theme) => css`
   padding: ${contentThumbnailPadding};
   padding-right: 0;
   padding-bottom: 0;
-  background: ${theme.color.gray};
+  background: ${theme.color.background};
   border-radius: 4px;
 `;
 

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -21,7 +21,7 @@ const globalCss = (theme: Theme) => css`
   }
 
   :root {
-    color: ${theme.color.black};
+    color: ${theme.color.gray06};
 
     body {
       -webkit-user-select: none;

--- a/src/styles/Theme/Theme.ts
+++ b/src/styles/Theme/Theme.ts
@@ -2,6 +2,18 @@ const theme = {
   color: {
     black: '#495057',
     gray: '#F7F7F7',
+    primary: '#F15A25',
+    primary_disabled: '#E9BCAC',
+    background: '#D6DBDC', // screen background
+    gray01: '#C2CBCD',
+    gray02: '#B7C6CD',
+    gray03: '#A3B3BA',
+    gray04: '#717D82',
+    gray05: '#5A676A',
+    gray06: '#2D2D2D', // main article text
+    dim01: 'rgba(0, 0, 0, 0.2)', // main thumnail tag background
+    dim02: 'rgba(0, 0, 0, 0.3)',
+    dim03: 'rgba(0, 0, 0, 0.6)', //screen dim
   },
 };
 


### PR DESCRIPTION
## ⛳️작업 내용
emotion color를 적용했습니다. 
네이밍은 디자인 시스템에 선언된 그대로를 가져갔습니다.

한 가지 걸리는 점은 `primary_disabled` 이 친구 입니다. 따로 어떻게 정의할까 많이 고민하다가 사용 목적에 맞도록 적용하는 것이 가장 좋다고 생각되어 해당 방식으로 적용했습니다.(레퍼런스 1 참조)

처음에 색을 선언할때 `gey1`과 같이하려다가 추후에 디자이너분들이 계속 `gey01`로 사용될것으로 예상되어 그대로를 입력했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
```tsx
const HeaderButtonCss = (theme: Theme) => css`
  width: 32px;
  height: 32px;
  background: ${theme.color.background};
  font-weight: 700;
  font-size: 10px;
`;
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
1. https://zeroheight.com/blog/naming-conventions-for-your-design-system/
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
