### PR TITLE
NavigationBar 컴포넌트 개발

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ const customJestConfig = {
   testRegex: '(/__tests__/.*|(\\.|/)(test))\\.[jt]sx?$',
   collectCoverageFrom: ['**/src/**/*.{js,ts,jsx,tsx}'],
   moduleNameMapper: {
+    '~/(.*)': '<rootDir>/src/$1',
     '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2|ico)$': 'identity-obj-proxy',
   },
   moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],

--- a/src/__test__/utils/customRender.tsx
+++ b/src/__test__/utils/customRender.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import { ThemeProvider } from '@emotion/react';
+import { render, RenderOptions } from '@testing-library/react';
+
+import Theme from '~/styles/Theme';
+
+function RenderWithAllProviders({ children }: PropsWithChildren<unknown>) {
+  return <ThemeProvider theme={Theme}>{children}</ThemeProvider>;
+}
+
+export function customRender(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, { wrapper: RenderWithAllProviders, ...options });
+}

--- a/src/__test__/utils/index.ts
+++ b/src/__test__/utils/index.ts
@@ -1,0 +1,1 @@
+export { customRender } from './customRender';

--- a/src/components/common/NavigationBar/NavigationBar.test.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { customRender } from '~/__test__/utils';
+
+import NavigationBar from './NavigationBar';
+
+const mockTitle = 'title';
+
+describe('components/common/NavigationBar', () => {
+  it('render title props', () => {
+    customRender(<NavigationBar title={mockTitle} />);
+    expect(screen.getByText(mockTitle)).toBeInTheDocument();
+  });
+
+  it('render without title', () => {
+    customRender(<NavigationBar />);
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('render back button', () => {
+    customRender(<NavigationBar />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  //TODO: back button click test
+
+  it('render rightElement', () => {
+    customRender(<NavigationBar rightElement={<p>{mockTitle}</p>} />);
+    expect(screen.getByText(mockTitle)).toBeInTheDocument();
+  });
+
+  it('render without rightElement', () => {
+    customRender(<NavigationBar />);
+    expect(screen.getByRole('navigation').childNodes.length).toEqual(1);
+  });
+});

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,0 +1,51 @@
+import { ReactElement } from 'react';
+import { css, Theme } from '@emotion/react';
+
+import { IconButton } from '~/components/common/Button';
+import useInternalRouter, { RouterPathType } from '~/hooks/common/useInternalRouter';
+
+interface NavigationBarProps {
+  backLink?: RouterPathType;
+  title?: string;
+  rightElement?: ReactElement;
+}
+
+export default function NavigationBar({ backLink, title, rightElement }: NavigationBarProps) {
+  const router = useInternalRouter();
+
+  const onClickBackButton = () => {
+    if (backLink) {
+      router.push(backLink);
+      return;
+    }
+    router.back();
+  };
+
+  return (
+    <nav css={navCss}>
+      <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />
+      {title && <h1 css={headingCss}>{title}</h1>}
+      {rightElement ? rightElement : <></>}
+    </nav>
+  );
+}
+
+const navCss = css`
+  position: relative;
+  width: 100%;
+  height: 44px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const headingCss = (theme: Theme) => css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  color: ${theme.color.gray05};
+  font-size: 1rem;
+`;

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -25,7 +25,7 @@ export default function NavigationBar({ backLink, title, rightElement }: Navigat
     <nav css={navCss}>
       <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />
       {title && <h1 css={headingCss}>{title}</h1>}
-      {rightElement && rightElement}
+      {rightElement && <>{rightElement}</>}
     </nav>
   );
 }

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -25,7 +25,7 @@ export default function NavigationBar({ backLink, title, rightElement }: Navigat
     <nav css={navCss}>
       <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />
       {title && <h1 css={headingCss}>{title}</h1>}
-      {rightElement ? rightElement : <></>}
+      {rightElement && rightElement}
     </nav>
   );
 }

--- a/src/components/common/NavigationBar/index.test.tsx
+++ b/src/components/common/NavigationBar/index.test.tsx
@@ -1,0 +1,12 @@
+import { customRender } from '~/__test__/utils';
+
+import DefaultNavigationBar from './index';
+import NavigationBar from './NavigationBar';
+
+describe('components/common/NavigationBar/index', () => {
+  it('render samethings', () => {
+    const { container: defaultContainer } = customRender(<DefaultNavigationBar />);
+    const { container } = customRender(<NavigationBar />);
+    expect(defaultContainer).toEqual(container);
+  });
+});

--- a/src/components/common/NavigationBar/index.tsx
+++ b/src/components/common/NavigationBar/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './NavigationBar';

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -1,4 +1,10 @@
-import Button, { CTAButton, FilledButton, GhostButton } from '~/components/common/Button';
+import Button, {
+  CTAButton,
+  FilledButton,
+  GhostButton,
+  IconButton,
+} from '~/components/common/Button';
+import NavigationBar from '~/components/common/NavigationBar';
 import { useToast } from '~/store/Toast';
 
 export default function Test() {
@@ -6,6 +12,8 @@ export default function Test() {
 
   return (
     <div>
+      <NavigationBar title="Title" rightElement={<IconButton iconName="DeleteIcon" light />} />
+
       <Button>텍스트 버튼</Button>
 
       <GhostButton>고스트 라지</GhostButton>


### PR DESCRIPTION
## ⛳️작업 내용

`NavigationBar` 컴포넌트를 개발했어요

framer 상, `2-depth ~` 부분을 컴포넌트화 했어요.

> 다른 NavigationBar의 경우 Main view만 있기 때문에 모듈화하지 않는 게 좋을 거 같았어용

구현체의 왼쪽 back 버튼의 경우 링크가 있을 시 해당 링크로, 없을 시 `back` 하도록 개발하였고

오른쪽 버튼 구역의 경우 `ReactElement`를 props로 받도록 했슴다

> `_app` 에서 컴포넌트를 그린 후, 전역 상태라던지 라우트별 오브젝트를 맵핑해서 관리할까도 생각해봤는데 더 유지보수에 어려운 방법이지 않을까... 라는 생각으로 이렇게 개발해봤어요 🥲 

## 📸스크린샷

![스크린샷 2022-04-29 오후 10 49 57](https://user-images.githubusercontent.com/26461307/165957736-a2fa8412-1b38-43e7-8b40-985233b35892.png)


## ⚡️사용 방법

```jsx
import NavigationBar from '~/components/common/NavigationBar';

// 모든 props 주입 시
<NavigationBar backLink="/" title="Title" rightElement={<IconButton iconName="DeleteIcon" light />} />
// router.back 실행을 위해서는
<NavigationBar title="Title" rightElement={<IconButton iconName="DeleteIcon" light />} />
// router.back + 아무것도 없이
<NavigationBar  />

```

## 🎇 이슈

테스트 코드에 대한 부분이지만, 현재 css prop를 **jest 환경**에서 Invalid하게 인식함(warning)과 동시에 스타일이 적용되지 않는 이슈가 있어요.

서치를 해본 결과 [해당 이슈](https://github.com/emotion-js/emotion/issues/1759)를 찾았지만 정확한 환경을 구현해서 제보한 사람이 없어 이슈가 닫힌 걸로 보여요 ㅠ

`css prop을 invalid`하게 인식하는 warning은 
```jsx
/* @jsxImportSource @emotion/react */
```
을 컴포넌트 최상단에 작성해주면 발생하지 않지만, 다른 해결 방법이 있지 않을까 생각되어 [스택오버플로우에 질문글](https://stackoverflow.com/questions/72058933/testing-library-with-emotion-css)을 올려봤어요.

경험해보신 분이 계시면 해결 방법 공유 부탁드릴게요 ㅠㅠ

> 물론 구현에는 문제가 없어, 시급한 것은 아니기에 바로 PR 올려드립니다!!




<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
