### PR TITLE
ThumbnailTag, Tag 디자인 추가 및 변경 #92

### DIFF
--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,22 +1,28 @@
 import { css, Theme } from '@emotion/react';
 
+import { CloseIcon } from './icons';
+
 // TODO: Tag에 대한 프로퍼티가 정의되면 text, onDelete은 변경될 예정입니다.
-interface Props {
-  text: string;
+export interface TagType {
+  id: number;
+  content: string;
+}
+export interface TagProps {
+  tag: TagType;
   deletable?: boolean;
   onDelete?: () => void;
 }
 
-export default function Tag({ text, deletable = false, onDelete = () => {} }: Props) {
+export default function Tag({ tag, deletable = false, onDelete = () => {} }: TagProps) {
   return (
-    <button css={tagCss}>
-      #{text}
+    <div css={tagCss}>
+      #{tag.content}
       {deletable && (
-        <div css={iconCss} onClick={() => onDelete()}>
-          X
-        </div>
+        <button css={closeButtonCss} onClick={() => onDelete()}>
+          <CloseIcon size={15} />
+        </button>
       )}
-    </button>
+    </div>
   );
 }
 
@@ -37,7 +43,7 @@ const tagCss = (theme: Theme) => css`
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
-  height: 28px;
+  height: 24px;
   padding: 0 6px;
   border-radius: 4px;
   background-color: ${selectRandomColor(theme)};
@@ -46,13 +52,8 @@ const tagCss = (theme: Theme) => css`
   line-height: 150%;
 `;
 
-// TODO: ICON 추가 되면 제거되야 됩니다.
-const iconCss = css`
-  display: flex;
-  align-items: center;
-  justify-content: center;
+const closeButtonCss = css`
+  padding: 0;
+  line-height: 0;
   margin-left: 4px;
-  font-size: 14px;
-  width: 16px;
-  height: 16px;
 `;


### PR DESCRIPTION
## ⛳️작업 내용
- 기존의 28px -> 24px로 높이 변경되었습니다.
- API 연결 전에 Tag를 들어올것을 예상하고 작성을 해보았습니다.
- Props 이름을 변경했습니다.

- ThumbnailTag의 마지막 요소에 대한 사용 변경을 했습니다.
  - 마지막요소에 넣는것보다 사용하는쪽에서 넣어주는게 어떨까해서 변경해보았습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="336" alt="스크린샷 2022-05-01 오후 10 24 39" src="https://user-images.githubusercontent.com/59507527/166148014-fb0cf07a-b029-41e9-8ac7-ba5ba6d64fe8.png">

<img width="580" alt="스크린샷 2022-05-01 오후 10 35 46" src="https://user-images.githubusercontent.com/59507527/166148350-e1d374b0-358f-4539-9e46-ab208642f45e.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
```tsx
<Tag tag={{ id: 0, content: '하이' }} />
<Tag deletable tag={{ id: 0, content: '하이' }} />
```

```tsx
<div css={contentTagsCss}>
  <ThumbnailTag text="영감" />
  <ThumbnailTag text="UX/UI" />
  <ThumbnailTag text="브랜드 디자인 레퍼런스 모음집" />
  <ThumbnailTag text="디자인인사이트" />
</div>

const contentTagsCss = css`
 //(...생략)
  padding-right: 16px;
`;
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
