### PR TITLE
CheckList 컴포넌트의 input id에 react18의useId 사용하기

### DIFF
--- a/src/components/common/CheckList.tsx
+++ b/src/components/common/CheckList.tsx
@@ -1,23 +1,22 @@
-import React, { PropsWithChildren, useEffect, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useId, useState } from 'react';
 import { css, useTheme } from '@emotion/react';
 
 import { CheckCircleIcon, ChevronIcon } from './icons';
 
 export interface CheckListProps {
-  id: string;
   isChecked: boolean;
   onToggle: (checked: boolean) => void;
   onClick?: VoidFunction;
 }
 
 export default function CheckList({
-  id,
   children,
   isChecked,
   onToggle,
   onClick,
 }: PropsWithChildren<CheckListProps>) {
   const theme = useTheme();
+  const id = useId();
 
   const [checked, setChecked] = useState(isChecked);
 
@@ -31,8 +30,13 @@ export default function CheckList({
 
   return (
     <div css={checkListContainerCss}>
-      <input css={inputCheckboxHiddenCss} id={id} type="checkbox" onChange={onCheck} />
-      <label htmlFor={id}>
+      <input
+        css={inputCheckboxHiddenCss}
+        id={`check-list-${id}`}
+        type="checkbox"
+        onChange={onCheck}
+      />
+      <label htmlFor={`check-list-${id}`}>
         <CheckCircleIcon color={checked ? '' : theme.color.gray01} />
       </label>
       <span css={childrenWrapperCss} onClick={onClick}>

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -125,7 +125,6 @@ export default function Test() {
         isSuccess
       />
       <CheckList
-        id="checkbox_1"
         isChecked={true}
         onToggle={checked => {
           console.log(checked);
@@ -134,7 +133,6 @@ export default function Test() {
         체크 리스트
       </CheckList>
       <CheckList
-        id="checkbox_2"
         isChecked={false}
         onToggle={checked => {
           console.log(checked);


### PR DESCRIPTION
## ⛳️작업 내용
- 리뷰 내용에 따라 기존의 id를 Props로 주입받는 형태가 아닌 내부에서 유니크한 id를 생성해서 사용한것으로 Refactor하였습니다.

```
id의 경우에는 굳이 외부 주입 받지 않더라도 useId 등으로 컴포넌트 안에서 생성해 줄 수 있을 것 같아요!

(다만 react 18 요소 사용을 위한 패치인 https://github.com/depromeet/11th_7team_web/pull/87 피알이 머지되지 않아서, 추후에 TODO 이슈로 만들어두는게 좋을 것 같네요)

관련 링크: https://github.com/depromeet/11th_7team_web/pull/86#discussion_r862462220
```
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
- 잘동동작합니당!
<img width="482" alt="image" src="https://user-images.githubusercontent.com/59507527/166293048-eda7a674-8939-4764-ae5a-19c776a11f31.png">
<img width="482" alt="image" src="https://user-images.githubusercontent.com/59507527/166293091-8f9f6457-37de-41ca-9df7-ff135b341519.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
- 기존에 id props 주입 부분이 삭제되었습니다.
```tsx
<CheckList
  isChecked={false}
  onToggle={checked => {
    console.log(checked);
  }}
  onClick={() => {}}
>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
