### PR TITLE
navigationBar 사용 시 backLink 사용하지 않으면 아이콘을 표시하지 않음

### DIFF
--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -23,7 +23,7 @@ export default function NavigationBar({ backLink, title, rightElement }: Navigat
 
   return (
     <nav css={navCss}>
-      <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />
+      {backLink && <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />}
       {title && <h1 css={headingCss}>{title}</h1>}
       {rightElement && <>{rightElement}</>}
     </nav>


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- navigationBar 에서 `backLink` 항목을 주입하지 않았다면 아이콘을 표시하지 않도록 표시합니다. 기존에는 좌측에 있는 `<` 아이콘이 표시됐습니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
