### PR TITLE
영감 추가 - 이미지 타입

### DIFF
--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -36,5 +36,8 @@ const closeIconCss = css`
   position: absolute;
   top: 16px;
   right: 16px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   z-index: 1;
 `;

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -86,7 +86,7 @@ export function MemoText({
           <div />
           <span css={textLimitCss}>
             <span css={editable && textLimitCurrentCss}>{debouncedValue.length}</span>
-            {wordLimit && `/150`}
+            {`/${wordLimit ?? 150}`}
           </span>
         </div>
       }

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -28,6 +28,11 @@ export interface MemoTextProps {
   editable?: boolean;
 
   /**
+   * 작성 가능 여부입니다. (영감 추가)
+   */
+  writable?: boolean;
+
+  /**
    * 글자 수 제한입니다. 지정하지 않을 경우 사용하지 않습니다.
    */
   wordLimit?: number;
@@ -47,6 +52,7 @@ export function MemoText({
   label,
   placeholder,
   editable,
+  writable,
   wordLimit,
   onChange: onValueChange,
   onSaveClick,
@@ -85,12 +91,12 @@ export function MemoText({
         <div css={flexBetweenWrapper}>
           <div />
           <span css={textLimitCss}>
-            <span css={editable && textLimitCurrentCss}>{debouncedValue.length}</span>
+            <span css={(editable || writable) && textLimitCurrentCss}>{debouncedValue.length}</span>
             {`/${wordLimit ?? 150}`}
           </span>
         </div>
       }
-      disabled={!editable}
+      disabled={!editable && !writable}
     />
   );
 }

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -68,7 +68,7 @@ export function MemoText({
       onChange={onChange}
       placeholder={placeholder ?? '어떤 것이 영감을 주었나요?'}
       maxLength={wordLimit}
-      fixedHeight={405}
+      fixedHeight={100}
       label={
         <div css={flexBetweenWrapper}>
           <label htmlFor={'input-' + id} css={labelCss}>

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,16 +1,31 @@
 import { css } from '@emotion/react';
 
+import { CTAButton } from '~/components/common/Button';
 import ImageContent from '~/components/common/ImageContent';
+import NavigationBar from '~/components/common/NavigationBar';
+import { MemoText } from '~/components/common/TextField';
 
 export default function AddImage() {
   return (
     <article css={addImageCss}>
-      <ImageContent
-        src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
-        alt="mock"
-      />
+      <NavigationBar title="이미지 추가" />
+      <div css={imgBoxCss}>
+        <ImageContent
+          src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
+          alt="mock"
+        />
+      </div>
+      <MemoText />
+      <CTAButton type="submit">Tang!</CTAButton>
     </article>
   );
 }
 
-const addImageCss = css``;
+const addImageCss = css`
+  display: flex;
+  flex-direction: column;
+`;
+
+const imgBoxCss = css`
+  margin: 16px 0;
+`;

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -16,7 +16,7 @@ export default function AddImage() {
             alt="mock"
           />
         </div>
-        <MemoText />
+        <MemoText writable />
       </section>
       <section css={addImageBottomCss}>
         <CTAButton type="submit">Tang!</CTAButton>

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -9,14 +9,18 @@ export default function AddImage() {
   return (
     <article css={addImageCss}>
       <NavigationBar title="이미지 추가" />
-      <div css={imgBoxCss}>
-        <ImageContent
-          src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
-          alt="mock"
-        />
-      </div>
-      <MemoText />
-      <CTAButton type="submit">Tang!</CTAButton>
+      <section css={addImageTopCss}>
+        <div css={imgBoxCss}>
+          <ImageContent
+            src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
+            alt="mock"
+          />
+        </div>
+        <MemoText />
+      </section>
+      <section css={addImageBottomCss}>
+        <CTAButton type="submit">Tang!</CTAButton>
+      </section>
     </article>
   );
 }
@@ -24,6 +28,17 @@ export default function AddImage() {
 const addImageCss = css`
   display: flex;
   flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+`;
+
+const addImageTopCss = css`
+  flex-grow: 1;
+  overflow-y: auto;
+`;
+
+const addImageBottomCss = css`
+  margin: 8px 0 16px 0;
 `;
 
 const imgBoxCss = css`


### PR DESCRIPTION
## ⛳️작업 내용
### [design: add image page 디자인 작성](https://github.com/depromeet/11th_7team_web/commit/bbde14eb2c3a7677afb6ffe290c3ccbebead91b4)

#### /add/image 페이지
일단 정말 순수하게 이미지 레이아웃만 작성했어요!
API에 수정도 필요한 상황이라.. 어떠한 기능도 들어가 있지 않지만, 전반적인 UI 작성 후에 `영감 추가`기능 작성 들어갈 예정입니다.
그리고 [태그 추가] 부분은 대윤님 작성이 끝난 뒤에 넣으려구요. 아직 추가 안 된 것 맞지요?!

### [fix: memoText word limit 표시되지 않는 에러 수정](https://github.com/depromeet/11th_7team_web/commit/c3f53f2757968e370263043cf67fffd44a99450b)
### [feat: memoText 컴포넌트 writable 프로퍼티 추가](https://github.com/depromeet/11th_7team_web/commit/cb98d70f22dcb30229541acd21cc08ca24f41d70)
- memoText의 fixedHeight이 405로 되어 있는데, 프레이머에서 아무리 봐도 405로 되어 있는 UI를 찾을 수가 없어서 일단 100으로 디자인 수정했습니다 (제가 잘못한 거라면 말씀해주세용)
- editable이라는 프롭스가 false라면 작성이 되지 않았는데, 영감 추가 페이지에서는 default가 작성이 되어야 하는 상황이라 writable이라는 프롭스를 추가했어요.(글 작성 o, 펜슬 아이콘 x) 후에 영감 수정하는 기능 넣을 때 전반적으로 리팩터링을 해볼게요!

## 👀 궁금한 점
... 나중에 이미지를 올리는 기능을 추가할 때, 핸드폰 갤러리랑 연동을 어떻게 해야할 지에 대해서는 고민 좀 해봐야할 것 같아요!
요건 한번 틈틈이 알아보겠습니다. 혹시 아시는 분 있다면 의견 환영입니다 :)
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="468" alt="image" src="https://user-images.githubusercontent.com/69200669/166904562-d9002e01-2797-4dbb-9fe0-59f30334a0d7.png">


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
