### PR TITLE
영감 추가 - 링크 타입 

### DIFF
--- a/src/components/LinkThumbnail.tsx
+++ b/src/components/LinkThumbnail.tsx
@@ -14,9 +14,14 @@ export interface LinkThumbnailMetaData {
 export interface LinkThumbnailProps {
   edit?: boolean;
   thumbnail: LinkThumbnailMetaData;
+  onDelete?: VoidFunction;
 }
 
-export default function LinkThumbnail({ edit = false, thumbnail }: LinkThumbnailProps) {
+export default function LinkThumbnail({
+  edit = false,
+  thumbnail,
+  onDelete: _onDelete,
+}: LinkThumbnailProps) {
   const hasImage = () => {
     return Boolean(thumbnail?.imageUrl);
   };
@@ -43,7 +48,12 @@ export default function LinkThumbnail({ edit = false, thumbnail }: LinkThumbnail
         {hasImage() && (
           <img css={linkThumbnailImageCss} src={thumbnail.imageUrl} alt={thumbnail.alt} />
         )}
-        <IconButton light iconName="CancelIcon" css={closeButtonCss(edit)} onClick={onDelete} />
+        <IconButton
+          light
+          iconName="CancelIcon"
+          css={closeButtonCss(edit)}
+          onClick={_onDelete ?? onDelete}
+        />
       </article>
     </a>
   );

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -1,22 +1,14 @@
-import { useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import { PlusIcon } from '~/components/common/icons';
+import { Input } from '~/components/common/TextField/Input';
+import LinkThumbnail from '~/components/LinkThumbnail';
 import useInput from '~/hooks/common/useInput';
+import { OpenGraph } from '~/pages/add/link';
 import { useToast } from '~/store/Toast';
 import { validator } from '~/utils/validator';
 
-import { Input } from '../common/TextField/Input';
-import LinkThumbnail from '../LinkThumbnail';
-
-interface OpenGraph {
-  description: string;
-  site_name: string;
-  title: string;
-  url: string;
-  imageUrl?: string;
-}
-
+// TODO openGraph 관련 api 개발 후 삭제 예정
 const TEMP_OG: OpenGraph = {
   description: '네이버 메인에서 다양한 정보와 유용한 컨텐츠를 만나 보세요',
   title: '네이버',
@@ -25,22 +17,23 @@ const TEMP_OG: OpenGraph = {
   imageUrl: 'https://s.pstatic.net/static/www/mobile/edit/2016/0705/mobile_212852414260.png',
 };
 
-function PlusBtn({ onClick }: { onClick: VoidFunction }) {
-  return (
-    <button css={btnCss} onClick={onClick}>
-      <PlusIcon color="white" />
-    </button>
-  );
+interface LinkInputProps {
+  openGraph: OpenGraph | null;
+  setOpenGraph: React.Dispatch<React.SetStateAction<OpenGraph | null>>;
 }
 
-export default function LinkInput() {
+export default function LinkInput({ openGraph, setOpenGraph }: LinkInputProps) {
+  const url = useInput({ useDebounce: true });
+
   const { fireToast } = useToast();
-  const [openGraph, setOpenGraph] = useState<OpenGraph | null>(null);
-  const url = useInput({});
 
   const showErrorMessage = () => fireToast({ content: '유효하지 않은 주소입니다.' });
 
-  const getOpenGraph = () => {
+  const getOpenGraph = (
+    e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    // TODO openGraph 관련 api 개발 후 수정 필요
     validator({ value: url.value, type: 'url' }) ? setOpenGraph(TEMP_OG) : showErrorMessage();
   };
 
@@ -49,7 +42,7 @@ export default function LinkInput() {
       {openGraph ? (
         <LinkThumbnail thumbnail={openGraph} edit onDelete={() => setOpenGraph(null)} />
       ) : (
-        <>
+        <form>
           <Input
             placeholder="영감이 되는 링크를 붙여 넣어보세요"
             fixedHeight={32}
@@ -57,9 +50,23 @@ export default function LinkInput() {
             onChange={url.onChange}
           />
           <PlusBtn onClick={getOpenGraph} />
-        </>
+        </form>
       )}
     </div>
+  );
+}
+
+function PlusBtn({
+  onClick,
+}: {
+  onClick: (
+    e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLElement, MouseEvent>
+  ) => void;
+}) {
+  return (
+    <button css={btnCss} onClick={onClick} type="submit">
+      <PlusIcon color="white" />
+    </button>
   );
 }
 

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -1,0 +1,36 @@
+import { css, Theme } from '@emotion/react';
+
+import { PlusIcon } from '~/components/common/icons';
+
+import { Input } from '../common/TextField/Input';
+
+function PlusBtn() {
+  return (
+    <button css={btnCss}>
+      <PlusIcon color="white" />
+    </button>
+  );
+}
+
+export default function LinkInput() {
+  return (
+    <div css={LinkInputCss}>
+      <Input placeholder="영감이 되는 링크를 붙여 넣어보세요" fixedHeight={32} />
+      <PlusBtn />
+    </div>
+  );
+}
+
+const LinkInputCss = css`
+  position: relative;
+`;
+
+const btnCss = (theme: Theme) => css`
+  position: absolute;
+  inset: 0 0 auto auto;
+  width: 40px;
+  height: 32px;
+  padding-top: 3px;
+  ${`border-radius: 0 ${theme.borderRadius.default} ${theme.borderRadius.default} 0;`}
+  background-color: ${theme.color.gray05};
+`;

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -12,7 +12,7 @@ import { validator } from '~/utils/validator';
 const TEMP_OG: OpenGraph = {
   description: '네이버 메인에서 다양한 정보와 유용한 컨텐츠를 만나 보세요',
   title: '네이버',
-  site_name: 'naver',
+  siteName: 'naver',
   url: 'https://www.naver.com',
   imageUrl: 'https://s.pstatic.net/static/www/mobile/edit/2016/0705/mobile_212852414260.png',
 };

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -4,6 +4,7 @@ import { css, Theme } from '@emotion/react';
 import { PlusIcon } from '~/components/common/icons';
 import useInput from '~/hooks/common/useInput';
 import { useToast } from '~/store/Toast';
+import { validator } from '~/utils/validator';
 
 import { Input } from '../common/TextField/Input';
 import LinkThumbnail from '../LinkThumbnail';
@@ -40,7 +41,7 @@ export default function LinkInput() {
   const showErrorMessage = () => fireToast({ content: '유효하지 않은 주소입니다.' });
 
   const getOpenGraph = () => {
-    url.value ? setOpenGraph(TEMP_OG) : showErrorMessage();
+    validator({ value: url.value, type: 'url' }) ? setOpenGraph(TEMP_OG) : showErrorMessage();
   };
 
   return (

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -1,22 +1,63 @@
+import { useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import { PlusIcon } from '~/components/common/icons';
+import useInput from '~/hooks/common/useInput';
+import { useToast } from '~/store/Toast';
 
 import { Input } from '../common/TextField/Input';
+import LinkThumbnail from '../LinkThumbnail';
 
-function PlusBtn() {
+interface OpenGraph {
+  description: string;
+  site_name: string;
+  title: string;
+  url: string;
+  imageUrl?: string;
+}
+
+const TEMP_OG: OpenGraph = {
+  description: '네이버 메인에서 다양한 정보와 유용한 컨텐츠를 만나 보세요',
+  title: '네이버',
+  site_name: 'naver',
+  url: 'https://www.naver.com',
+  imageUrl: 'https://s.pstatic.net/static/www/mobile/edit/2016/0705/mobile_212852414260.png',
+};
+
+function PlusBtn({ onClick }: { onClick: VoidFunction }) {
   return (
-    <button css={btnCss}>
+    <button css={btnCss} onClick={onClick}>
       <PlusIcon color="white" />
     </button>
   );
 }
 
 export default function LinkInput() {
+  const { fireToast } = useToast();
+  const [openGraph, setOpenGraph] = useState<OpenGraph | null>(null);
+  const url = useInput({});
+
+  const showErrorMessage = () => fireToast({ content: '유효하지 않은 주소입니다.' });
+
+  const getOpenGraph = () => {
+    url.value ? setOpenGraph(TEMP_OG) : showErrorMessage();
+  };
+
   return (
     <div css={LinkInputCss}>
-      <Input placeholder="영감이 되는 링크를 붙여 넣어보세요" fixedHeight={32} />
-      <PlusBtn />
+      {openGraph ? (
+        <LinkThumbnail thumbnail={openGraph} edit onDelete={() => setOpenGraph(null)} />
+      ) : (
+        <>
+          <Input
+            placeholder="영감이 되는 링크를 붙여 넣어보세요"
+            fixedHeight={32}
+            value={url.value}
+            onChange={url.onChange}
+          />
+          <PlusBtn onClick={getOpenGraph} />
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -8,7 +8,7 @@ import { MemoText } from '~/components/common/TextField';
 
 export interface OpenGraph {
   description: string;
-  site_name: string;
+  siteName: string;
   title: string;
   url: string;
   imageUrl?: string;

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import LinkInput from '~/components/add/LinkInput';
@@ -5,36 +6,49 @@ import { CTAButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
 
+export interface OpenGraph {
+  description: string;
+  site_name: string;
+  title: string;
+  url: string;
+  imageUrl?: string;
+}
+
 export default function AddLink() {
+  const [openGraph, setOpenGraph] = useState<OpenGraph | null>(null);
+
   return (
-    <article css={addTextCss}>
+    <article css={addLinkCss}>
       <NavigationBar title="링크 추가" />
-      <section css={addTextTopCss}>
+      <section css={addLinkTopCss}>
         <div css={linkBoxCss}>
-          <LinkInput />
+          <LinkInput openGraph={openGraph} setOpenGraph={setOpenGraph} />
         </div>
         <MemoText writable />
       </section>
-      <section css={addTextBottomCss}>
-        <CTAButton type="submit">Tang!</CTAButton>
+
+      <section css={addLinkBottomCss}>
+        <CTAButton disabled={!Boolean(openGraph)} type="submit">
+          Tang!
+        </CTAButton>
       </section>
     </article>
   );
 }
 
-const addTextCss = css`
+const addLinkCss = css`
   display: flex;
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
 `;
 
-const addTextTopCss = css`
+const addLinkTopCss = css`
   flex-grow: 1;
   overflow-y: auto;
 `;
 
-const addTextBottomCss = css`
+const addLinkBottomCss = css`
   margin: 8px 0 16px 0;
 `;
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -1,7 +1,43 @@
 import { css } from '@emotion/react';
 
+import LinkInput from '~/components/add/LinkInput';
+import { CTAButton } from '~/components/common/Button';
+import NavigationBar from '~/components/common/NavigationBar';
+import { MemoText } from '~/components/common/TextField';
+
 export default function AddLink() {
-  return <article css={addLinkCss}>링크 추가</article>;
+  return (
+    <article css={addTextCss}>
+      <NavigationBar title="링크 추가" />
+      <section css={addTextTopCss}>
+        <div css={linkBoxCss}>
+          <LinkInput />
+        </div>
+        <MemoText writable />
+      </section>
+      <section css={addTextBottomCss}>
+        <CTAButton type="submit">Tang!</CTAButton>
+      </section>
+    </article>
+  );
 }
 
-const addLinkCss = css``;
+const addTextCss = css`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+`;
+
+const addTextTopCss = css`
+  flex-grow: 1;
+  overflow-y: auto;
+`;
+
+const addTextBottomCss = css`
+  margin: 8px 0 16px 0;
+`;
+
+const linkBoxCss = css`
+  margin: 16px 0;
+`;

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -20,7 +20,7 @@ interface Validator {
 const pattern: Record<ValidatorType, RegExp> = {
   email:
     /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+\.)+[a-zA-Z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}))$/,
-  url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g,
+  url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/g,
 };
 
 export const validator = ({ value, type, rule }: Validator) => {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,36 @@
+type ValidatorType = 'email' | 'url';
+
+interface Validator {
+  /**
+   * value 유효성을 체크할 값입니다.
+   */
+  value: string;
+
+  /**
+   * type 유효성 판단 타입을 적습니다.
+   */
+  type?: ValidatorType;
+
+  /**
+   * 유효성을 판단할 정규식을 직접 넣습니다.
+   */
+  rule?: RegExp;
+}
+
+const pattern: Record<ValidatorType, RegExp> = {
+  email:
+    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+\.)+[a-zA-Z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}))$/,
+  url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g,
+};
+
+export const validator = ({ value, type, rule }: Validator) => {
+  if (rule) {
+    return typeof value === 'string' && Boolean(value.match(rule));
+  }
+
+  if (type) {
+    return typeof value === 'string' && Boolean(value.match(pattern[type]));
+  }
+
+  return false;
+};


### PR DESCRIPTION
## ⛳️작업 내용
### [design: add link page 디자인 추가](https://github.com/depromeet/11th_7team_web/commit/f65bb333a7cc185216ecaec94f43cbbd4a9867d2)
디자인 간단하게 작성했고..! 영감 추가 관련 기능은 아무래도 유저 기능이 개발된 이후에 api 본격적으로 붙이고, 할 수 있지 않을까 싶어요.
일단 여기까지 리팩터링 간단하게 거친 다음에 영감 보기 view로 이동할까 합니다!

### [feat: validator util 작성 및 link input component 적용](https://github.com/depromeet/11th_7team_web/commit/f7d5b78f3f03a61ee461270b5bad7a01f3626c33)
유효성 체크하는 validator 유틸 함수를 작성했습니다.
input에 validator 프롭스를 넣으려고 하다가.. 제 페이지에서는 인풋에 잘못된 url을 넣으면 input 아래에 에러가 뜨는 것이 아니라,
toast 알람이 뜨기 때문에 해당 유틸 함수를 작성하는 것으로 했어요! 
나중에 확장하게 되면 훅을 작성해볼 수 있을 것 같은데, 아직까지 그 수준은 아닌 것 같아서 그냥 간단하게 validator.ts 정도로 멈췄습니다!


<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="339" alt="image" src="https://user-images.githubusercontent.com/69200669/166956385-405d4886-d510-40c7-bf19-d70522255ccf.png">

<img width="339" alt="image" src="https://user-images.githubusercontent.com/69200669/166956303-ef734cc9-3275-47ea-9afa-3eabcc73d4a8.png">


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
