### PR TITLE
chevronLeft가 필요 없는 경우 navigationBar 대신 목업 요소 사용

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,7 +1,6 @@
 import { css, Theme } from '@emotion/react';
 
 import { CTAButton, GhostButton } from '~/components/common/Button';
-import NavigationBar from '~/components/common/NavigationBar';
 import TextField from '~/components/common/TextField';
 import useInput from '~/hooks/common/useInput';
 
@@ -11,7 +10,7 @@ export default function Login() {
 
   return (
     <article css={loginCss}>
-      <NavigationBar />
+      <div css={navMockupCss} />
       <div css={loginIntroCardCss}></div>
       <form css={loginFieldSetCss}>
         <TextField
@@ -40,6 +39,10 @@ export default function Login() {
     </article>
   );
 }
+
+const navMockupCss = css`
+  height: 44px;
+`;
 
 const loginCss = css`
   display: flex;


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- navigationBar가 필요 없는 페이지에서는 mockUp 요소를 하나 만들어서 사용하도록 변경했어요.
  - #99 이슈와 관련되어 있습니다

Closed #117 

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

![image](https://user-images.githubusercontent.com/6638675/166985003-fabd72a0-c428-4d8d-b4b3-654e100eef2e.png)
![image](https://user-images.githubusercontent.com/6638675/166985083-fce7a07b-802e-416a-bb9e-ec75edf289c5.png)

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
