### PR TITLE
공용 컴포넌트 - CTABottomButton

### DIFF
--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -1,29 +1,25 @@
 import { ComponentProps } from 'react';
-import { css, Theme } from '@emotion/react';
+import { css, Theme, useTheme } from '@emotion/react';
+
+import { useUserAgent } from '~/hooks/common/useUserAgent';
 
 import { CTAButton } from './CTAButton';
 
 interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {}
 
 export function CTABottomButton(props: CTABottomButtonProps) {
+  const { isIos } = useUserAgent();
+  const theme = useTheme();
   const { children, ...rest } = props;
 
   return (
-    <CTAButton css={ctaButtonCss} {...rest}>
-      {children}
-    </CTAButton>
+    <div css={ctaBottomButtonCss(isIos(), theme)}>
+      <CTAButton {...rest}>{children}</CTAButton>
+    </div>
   );
 }
 
-const ctaButtonCss = (theme: Theme) => css`
-  width: 100%;
-  height: 56px;
-  font-size: 16px;
-  font-weight: ${theme.font.weight.semiBold};
-  color: ${theme.color.background};
-  background-color: ${theme.color.primary};
-
-  &:disabled {
-    background-color: ${theme.color.primary_disabled};
-  }
+const ctaBottomButtonCss = (isIos: boolean, theme: Theme) => css`
+  padding: ${isIos ? `8px 0 0 0` : `8px 0`};
+  background: ${theme.color.background};
 `;

--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -1,0 +1,29 @@
+import { ComponentProps } from 'react';
+import { css, Theme } from '@emotion/react';
+
+import { CTAButton } from './CTAButton';
+
+interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {}
+
+export function CTABottomButton(props: CTABottomButtonProps) {
+  const { children, ...rest } = props;
+
+  return (
+    <CTAButton css={ctaButtonCss} {...rest}>
+      {children}
+    </CTAButton>
+  );
+}
+
+const ctaButtonCss = (theme: Theme) => css`
+  width: 100%;
+  height: 56px;
+  font-size: 16px;
+  font-weight: ${theme.font.weight.semiBold};
+  color: ${theme.color.background};
+  background-color: ${theme.color.primary};
+
+  &:disabled {
+    background-color: ${theme.color.primary_disabled};
+  }
+`;

--- a/src/hooks/common/useUserAgent.ts
+++ b/src/hooks/common/useUserAgent.ts
@@ -12,6 +12,7 @@ const getMobileDetect = (userAgent: string): IUseUserAgent => {
   const isMobile = (): boolean => Boolean(isAndroid() || isIos());
   const isSSR = (): boolean => Boolean(userAgent.match(/SSR/i));
   const isDesktop = (): boolean => Boolean(!isMobile() && !isSSR());
+
   return {
     isAndroid,
     isIos,

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 
 import Button, {
@@ -7,6 +7,7 @@ import Button, {
   GhostButton,
   IconButton,
 } from '~/components/common/Button';
+import { CTABottomButton } from '~/components/common/Button/CTABottomButton';
 import CheckList from '~/components/common/CheckList';
 import { SearchIcon } from '~/components/common/icons';
 import NavigationBar from '~/components/common/NavigationBar';
@@ -20,6 +21,13 @@ import theme from '~/styles/Theme';
 export default function Test() {
   const { fireToast } = useToast();
   const { isMobile, isIos, isAndroid, isDesktop } = useUserAgent();
+  const [isSSR, setIsSSR] = useState(true);
+
+  useEffect(() => {
+    setIsSSR(false);
+  }, []);
+
+  if (isSSR) return null;
 
   return (
     <div>
@@ -39,6 +47,9 @@ export default function Test() {
 
         <CTAButton>CTA 버튼</CTAButton>
         <CTAButton disabled>CTA 버튼 비활성화</CTAButton>
+
+        <CTABottomButton>CTA Bottom 버튼(ios)</CTABottomButton>
+        <CTABottomButton>CTA Bottom 버튼(그 외)</CTABottomButton>
 
         <FilledButton>Filled 버튼</FilledButton>
         <FilledButton colorType="light">Filled 버튼 라이트</FilledButton>
@@ -96,9 +107,10 @@ export default function Test() {
       <Button onClick={() => fireToast({ content: '토스트 메세지' })}>토스트 발사 버튼</Button>
 
       <hr />
-      <TextField label={'라벨라벨'} placeholder={'플레이스 홀더'} />
+      <TextField readOnly label={'라벨라벨'} placeholder={'플레이스 홀더'} />
       <br />
       <TextField
+        readOnly
         label={'라벨라벨'}
         placeholder={'플레이스 홀더'}
         value={'성공한 상태의 input'}
@@ -107,6 +119,7 @@ export default function Test() {
       />
       <br />
       <TextField
+        readOnly
         label={'라벨벨'}
         placeholder={'검색'}
         feedback={'검색을 만들 땐 이렇게 사용하겠죠?'}
@@ -123,9 +136,16 @@ export default function Test() {
         isSuccess
       />
       <br />
-      <TextField as={'textarea'} rows={10} label={'라벨라벨'} placeholder={'플레이스 홀더'} />
+      <TextField
+        readOnly
+        as={'textarea'}
+        rows={10}
+        label={'라벨라벨'}
+        placeholder={'플레이스 홀더'}
+      />
       <br />
       <TextField
+        readOnly
         as={'textarea'}
         rows={10}
         label={'라벨라벨'}
@@ -150,7 +170,7 @@ export default function Test() {
       >
         체크 리스트
       </CheckList>
-      <SearchBar value={'asdasdasd'} />
+      <SearchBar readOnly value={'asdasdasd'} />
       <MemoText editable wordLimit={150} />
     </div>
   );

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -48,8 +48,7 @@ export default function Test() {
         <CTAButton>CTA 버튼</CTAButton>
         <CTAButton disabled>CTA 버튼 비활성화</CTAButton>
 
-        <CTABottomButton>CTA Bottom 버튼(ios)</CTABottomButton>
-        <CTABottomButton>CTA Bottom 버튼(그 외)</CTABottomButton>
+        <CTABottomButton>CTA Bottom 버튼(ios일 때 패딩 변화)</CTABottomButton>
 
         <FilledButton>Filled 버튼</FilledButton>
         <FilledButton colorType="light">Filled 버튼 라이트</FilledButton>


### PR DESCRIPTION
## ⛳️작업 내용

오늘 디자이너분들께 전달받은 내용이죠!

<img width="547" alt="image" src="https://user-images.githubusercontent.com/69200669/167256451-f0a84f88-6850-4543-9bbd-19a8a746d8ea.png">
ios인 경우 상하단의 padding이 바뀌는 것과, CTAButton 배경에 무조건 Gray 백그라운드가 들어가는 요소를 조합해서 만들었습니다.

## 질문!!

> 저의 경우 좌우 패딩을 페이지에서 16px씩 주고, 버튼에는 상하 패딩 8px 주는 방식으로 작성했는데요, 다들 어떻게 하셨는지 궁금하네요. 만약 페이지에서 좌우 패딩을 안넣은 경우에는 버튼 wrapper에 좌우 패딩을 넣긴 해야되거든요. 혹시 다른 분들 어떻게 하셨는지 궁금합니다. 
만약 좌우 패딩을 페이지에서 안 넣는 경우가 있으신가요? 그렇다면 추가적으로 props를 넣으려고 합니다. 의견 주시면 필요 시에 추가할게요~

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
### 데스크탑 사진 (위 아래 8px)
<img width="493" alt="image" src="https://user-images.githubusercontent.com/69200669/167256194-0c410f92-4cf4-43ca-abc5-8f8a0934942e.png">

### 아이폰 사진 (위에만 8px)
<img width="493" alt="image" src="https://user-images.githubusercontent.com/69200669/167256373-6dbb4335-bab9-4f27-bad7-c3b8045c06f8.jpeg">


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
