### PR TITLE
영감 추가 | 상세 - 태그 컨텐츠 추가

### DIFF
--- a/@types/tag.d.ts
+++ b/@types/tag.d.ts
@@ -1,1 +1,0 @@
-type TagType = Pick<TagInterface, 'content' | 'id'>;

--- a/src/components/common/Content/TagContent.tsx
+++ b/src/components/common/Content/TagContent.tsx
@@ -13,6 +13,9 @@ export interface TagContentProps {
    * 영감 편집일 경우, 편집 기능을 수행합니다.
    */
   onEdit: VoidFunction;
+  /**
+   * 단일 Tag 클릭 할 경우, Action을 넘겨 줍니다.
+   */
   onClickTag?: (tagId: number) => void;
 }
 

--- a/src/components/common/Content/TagContent.tsx
+++ b/src/components/common/Content/TagContent.tsx
@@ -1,0 +1,48 @@
+import { css, Theme } from '@emotion/react';
+
+import { IconButton } from '../Button';
+import { labelCss } from '../styles';
+import Tag from '../Tag';
+
+export interface TagContentProps {
+  label?: string;
+  tags: TagType[];
+  onEdit: VoidFunction;
+  onClickTag?: (tagId: number) => void;
+}
+
+export default function TagContent({ tags, label, onEdit, onClickTag }: TagContentProps) {
+  return (
+    <div css={tagContentWrapperCss}>
+      <span css={tagContentLabelCss}>{label ? label : '태그'}</span>
+      <div css={tagContentCss}>
+        {tags.map(tag => (
+          <Tag
+            content={tag.content}
+            key={tag.id}
+            onClick={() => {
+              onClickTag && onClickTag(tag.id);
+            }}
+          />
+        ))}
+        <IconButton iconName="PlusIcon" onClick={onEdit} />
+      </div>
+    </div>
+  );
+}
+const tagContentWrapperCss = css`
+  display: flex;
+  flex-direction: column;
+`;
+
+const tagContentLabelCss = (theme: Theme) => css`
+  ${labelCss(theme)}
+  margin-bottom: 12px;
+`;
+
+const tagContentCss = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+`;

--- a/src/components/common/Content/TagContent.tsx
+++ b/src/components/common/Content/TagContent.tsx
@@ -7,6 +7,11 @@ import Tag from '../Tag';
 export interface TagContentProps {
   label?: string;
   tags: TagType[];
+  /**
+   * 영감 추가일 경우, 추가 기능을 수행합니다.
+   *
+   * 영감 편집일 경우, 편집 기능을 수행합니다.
+   */
   onEdit: VoidFunction;
   onClickTag?: (tagId: number) => void;
 }

--- a/src/components/common/Content/TagContent.tsx
+++ b/src/components/common/Content/TagContent.tsx
@@ -19,10 +19,10 @@ export interface TagContentProps {
   onClickTag?: (tagId: number) => void;
 }
 
-export default function TagContent({ tags, label, onEdit, onClickTag }: TagContentProps) {
+export default function TagContent({ tags, label = '태그', onEdit, onClickTag }: TagContentProps) {
   return (
     <div css={tagContentWrapperCss}>
-      <span css={tagContentLabelCss}>{label ? label : '태그'}</span>
+      <span css={tagContentLabelCss}>{label}</span>
       <div css={tagContentCss}>
         {tags.map(tag => (
           <Tag

--- a/src/components/common/Content/styles.ts
+++ b/src/components/common/Content/styles.ts
@@ -1,8 +1,0 @@
-import { css } from '@emotion/react';
-
-/**
- * 공용으로 사용되는 라벨 스타일입니다.
- */
-export const contentWrapperCss = css`
-  padding: 16px 0;
-`;

--- a/src/components/common/Content/styles.ts
+++ b/src/components/common/Content/styles.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+
+/**
+ * 공용으로 사용되는 라벨 스타일입니다.
+ */
+export const contentWrapperCss = css`
+  padding: 16px 0;
+`;

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 
-import { labelCss } from '~/components/common/TextField/styles';
+import { labelCss } from '~/components/common/styles';
 import useInput from '~/hooks/common/useInput';
 
 import { EditIcon } from '../icons';

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useId } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import { CheckIcon } from '~/components/common/icons';
-import { labelCss } from '~/components/common/TextField/styles';
+import { labelCss } from '~/components/common/styles';
 
 import { Input, InputProps } from './Input';
 

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -1,7 +1,7 @@
 import { css, Theme } from '@emotion/react';
 
 /**
- * TextField 에서 공용으로 사용되는 라벨 스타일입니다.
+ * 공용으로 사용되는 라벨 스타일입니다.
  */
 export const labelCss = (theme: Theme) => css`
   display: block;

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,22 +1,46 @@
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
+import { contentWrapperCss } from '~/components/common/Content/styles';
+import TagContent from '~/components/common/Content/TagContent';
 import ImageContent from '~/components/common/ImageContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
 
 export default function AddImage() {
+  const tags = [
+    { id: 1, content: '1111' },
+    { id: 22, content: '22222' },
+    { id: 21, content: '13333' },
+    { id: 32, content: '27777' },
+    { id: 31, content: '1231321' },
+    { id: 42, content: '243241324' },
+    { id: 41, content: '1413241234234321' },
+    { id: 52, content: '243214324' },
+    { id: 51, content: '1234' },
+    { id: 62, content: '2423' },
+    { id: 61, content: '1432' },
+    { id: 72, content: '2423' },
+    { id: 81, content: '1423' },
+    { id: 92, content: '2423423' },
+  ];
+
   return (
     <article css={addImageCss}>
       <NavigationBar title="이미지 추가" />
       <section css={addImageTopCss}>
-        <div css={imgBoxCss}>
+        <div css={contentWrapperCss}>
           <ImageContent
             src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
             alt="mock"
           />
         </div>
-        <MemoText writable />
+        <div css={contentWrapperCss}>
+          <TagContent onEdit={() => {}} tags={tags} />
+        </div>
+        <div css={contentWrapperCss}>
+          <MemoText writable />
+        </div>
       </section>
       <section css={addImageBottomCss}>
         <CTAButton type="submit">Tang!</CTAButton>
@@ -39,8 +63,4 @@ const addImageTopCss = css`
 
 const addImageBottomCss = css`
   margin: 8px 0 16px 0;
-`;
-
-const imgBoxCss = css`
-  margin: 16px 0;
 `;

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
-import { contentWrapperCss } from '~/components/common/Content/styles';
 import TagContent from '~/components/common/Content/TagContent';
 import ImageContent from '~/components/common/ImageContent';
 import NavigationBar from '~/components/common/NavigationBar';
@@ -63,4 +62,8 @@ const addImageTopCss = css`
 
 const addImageBottomCss = css`
   margin: 8px 0 16px 0;
+`;
+
+const contentWrapperCss = css`
+  padding: 16px 0;
 `;

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 
 import LinkInput from '~/components/add/LinkInput';
 import { CTAButton } from '~/components/common/Button';
+import { contentWrapperCss } from '~/components/common/Content/styles';
+import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
 
@@ -21,10 +23,15 @@ export default function AddLink() {
     <article css={addLinkCss}>
       <NavigationBar title="링크 추가" />
       <section css={addLinkTopCss}>
-        <div css={linkBoxCss}>
+        <div css={contentWrapperCss}>
           <LinkInput openGraph={openGraph} setOpenGraph={setOpenGraph} />
         </div>
-        <MemoText writable />
+        <div css={contentWrapperCss}>
+          <TagContent onEdit={() => {}} tags={[]} />
+        </div>
+        <div css={contentWrapperCss}>
+          <MemoText writable />
+        </div>
       </section>
 
       <section css={addLinkBottomCss}>
@@ -50,8 +57,4 @@ const addLinkTopCss = css`
 
 const addLinkBottomCss = css`
   margin: 8px 0 16px 0;
-`;
-
-const linkBoxCss = css`
-  margin: 16px 0;
 `;

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 
 import LinkInput from '~/components/add/LinkInput';
 import { CTAButton } from '~/components/common/Button';
-import { contentWrapperCss } from '~/components/common/Content/styles';
 import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
@@ -57,4 +56,8 @@ const addLinkTopCss = css`
 
 const addLinkBottomCss = css`
   margin: 8px 0 16px 0;
+`;
+
+const contentWrapperCss = css`
+  padding: 16px 0;
 `;

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
+import { contentWrapperCss } from '~/components/common/Content/styles';
+import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
 import { Input } from '~/components/common/TextField/Input';
@@ -14,7 +16,7 @@ export default function AddText() {
     <article css={addTextCss}>
       <NavigationBar title="글 추가" />
       <section css={addTextTopCss}>
-        <div css={textBoxCss}>
+        <div css={contentWrapperCss}>
           <Input
             as="textarea"
             placeholder="영감을 작성해 보세요."
@@ -22,7 +24,12 @@ export default function AddText() {
             onChange={inspiringText.onChange}
           />
         </div>
-        <MemoText writable />
+        <div css={contentWrapperCss}>
+          <TagContent onEdit={() => {}} tags={[]} />
+        </div>
+        <div css={contentWrapperCss}>
+          <MemoText writable />
+        </div>
       </section>
       <section css={addTextBottomCss}>
         <CTAButton type="submit" disabled={isEmptyText}>
@@ -47,8 +54,4 @@ const addTextTopCss = css`
 
 const addTextBottomCss = css`
   margin: 8px 0 16px 0;
-`;
-
-const textBoxCss = css`
-  margin: 16px 0;
 `;

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
-import { contentWrapperCss } from '~/components/common/Content/styles';
 import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
@@ -54,4 +53,8 @@ const addTextTopCss = css`
 
 const addTextBottomCss = css`
   margin: 8px 0 16px 0;
+`;
+
+const contentWrapperCss = css`
+  padding: 16px 0;
 `;

--- a/src/remotes/tag.d.ts
+++ b/src/remotes/tag.d.ts
@@ -1,3 +1,5 @@
+type TagType = Pick<TagInterface, 'content' | 'id'>;
+
 interface TagInterface {
   id: number;
   memberResponse: MemberResponseInterface;


### PR DESCRIPTION
## ⛳️작업 내용
- 영감 추가 | 상세에서 사용되는 Tag 컨텐츠를 추가했습니다.
  -  영감의 Tag 리스트를 보여주며 **+버튼 눌렀을때 추가 | 편집**할 수 있습니다.
  - 즉, onEdit Props로 각각에 맞는 추가 | 편집을 진행할 수 있도록했습니다.
  - onClickTag를 이용하여 tag를 클릭했을 경우의 action을 props로 전달할 수 있도록했습니다.

- 디자인을 확인해보니 wrapper에서 padding 위아래 16px를 해주는 부분이 공통으로 사용되어 공통으로 선언하여 사용하도록했습니다.
  - `contentWrapperCss`
  - 해당 부분은 `~/components/common/Content/styles` 선언하여 공통 사용하도록했습니다! 의견있으면 알려주세요!
  - 다른 부분도 뺄까? 하였지만 논의 이후 변경하는게 좋겠다고 생각했습니다!

- labelCss가 다른 부분에서도 사용되어 TexField안에서 common으로 빼내었습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="629" alt="스크린샷 2022-05-08 오전 3 04 45" src="https://user-images.githubusercontent.com/59507527/167266647-ebd78daf-6a42-45a2-91eb-e8991d4ee202.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
### TagContnet 사용법
```tsx
<TagContent onEdit={() => { /** +버튼 눌렀을때 수정  | 편집 */}} tags={tags} />
```

```tsx
<TagContent onEdit={() => { /** 수정  | 편집 */}} tags={tags}  onClickTag={() => {/** 단일 tag 클릭 action */}} />
```

### contentWrapperCss 사용법
```tsx
import { contentWrapperCss } from '~/components/common/Content/styles';
<section css={addImageTopCss}>
  <div css={contentWrapperCss}>
    <ImageContent
      src="https://i.pinimg.com/564x/89/c5/4d/89c54d90c325a8c310363f4e9773a041.jpg"
      alt="mock"
    />
  </div>
  <div css={contentWrapperCss}>
    <TagContent onEdit={() => {}} tags={tags} />
  </div>
  <div css={contentWrapperCss}>
    <MemoText writable />
  </div>
</section>
```

### ~/components/common/Content/styles.ts
```tsx
import { css } from '@emotion/react';

export const contentWrapperCss = css`
  padding: 16px 0;
`;
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
