### PR TITLE
마이페이지 - 태그 관리

### DIFF
--- a/src/components/common/icons/RemoveCircleIcon.tsx
+++ b/src/components/common/icons/RemoveCircleIcon.tsx
@@ -1,8 +1,12 @@
+import { useTheme } from '@emotion/react';
+
 import Svg, { SvgProps } from '~/components/common/Svg';
 
-export function RemoveCircleIcon({ ...props }: SvgProps) {
+export function RemoveCircleIcon({ color, ...props }: SvgProps) {
+  const theme = useTheme();
+
   return (
-    <Svg viewBox={24} {...props}>
+    <Svg viewBox={24} color={color ? color : theme.color.primary} {...props}>
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2zm4 11H8c-.55 0-1-.45-1-1s.45-1 1-1h8c.55 0 1 .45 1 1s-.45 1-1 1z" />
     </Svg>
   );

--- a/src/components/my/Menu.tsx
+++ b/src/components/my/Menu.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+import { css, Theme } from '@emotion/react';
+
+export interface MenuProps {
+  label: string;
+  rightElement?: ReactElement;
+}
+
+export default function Menu({ label, rightElement }: MenuProps) {
+  return (
+    <li css={MenuCss}>
+      <span css={menuTitleCss}>{label}</span>
+      {rightElement && <>{rightElement}</>}
+    </li>
+  );
+}
+
+const MenuCss = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  height: 54px;
+  padding: 16px 8px;
+  border-bottom: solid 1px ${theme.color.gray01};
+`;
+
+const menuTitleCss = css`
+  font-size: 12px;
+`;

--- a/src/components/my/tag/MyTagItem.tsx
+++ b/src/components/my/tag/MyTagItem.tsx
@@ -1,0 +1,25 @@
+import { IconButton } from '~/components/common/Button';
+import Menu from '~/components/my/Menu';
+
+export default function MyTagItem({
+  tag,
+  onDelete,
+}: {
+  tag: TagType;
+  onDelete: (id: number) => void;
+}) {
+  return (
+    <Menu
+      label={tag.content}
+      rightElement={
+        <IconButton
+          onClick={() => {
+            onDelete(tag.id);
+          }}
+          iconName="RemoveCircleIcon"
+          light
+        />
+      }
+    />
+  );
+}

--- a/src/components/my/tag/MyTagItem.tsx
+++ b/src/components/my/tag/MyTagItem.tsx
@@ -1,25 +1,16 @@
 import { IconButton } from '~/components/common/Button';
 import Menu from '~/components/my/Menu';
 
-export default function MyTagItem({
-  tag,
-  onDelete,
-}: {
-  tag: TagType;
-  onDelete: (id: number) => void;
-}) {
+export default function MyTagItem({ tag }: { tag: TagType }) {
+  const onDelete = () => {
+    // TODO: Tag delete API 호출
+    console.log(tag.id);
+  };
+
   return (
     <Menu
       label={tag.content}
-      rightElement={
-        <IconButton
-          onClick={() => {
-            onDelete(tag.id);
-          }}
-          iconName="RemoveCircleIcon"
-          light
-        />
-      }
+      rightElement={<IconButton onClick={onDelete} iconName="RemoveCircleIcon" light />}
     />
   );
 }

--- a/src/pages/my/tag/index.tsx
+++ b/src/pages/my/tag/index.tsx
@@ -1,7 +1,70 @@
 import { css } from '@emotion/react';
 
+import { CTAButton, GhostButton } from '~/components/common/Button';
+import NavigationBar from '~/components/common/NavigationBar';
+import MyTagItem from '~/components/my/tag/MyTagItem';
+
 export default function MyTag() {
-  return <article css={myTagCss}>태그 관리</article>;
+  const tags: TagType[] = [
+    { id: 1, content: '안녕하세요!' },
+    { id: 2, content: '안녕하세요!!' },
+    { id: 3, content: '안녕하!!세요!' },
+    { id: 4, content: '안녕!!하세요!' },
+    { id: 5, content: '!!안녕하세요!' },
+    { id: 6, content: '안!!녕하세요!' },
+    { id: 7, content: '안녕!!하세!!요!' },
+    { id: 8, content: '!!안!!녕하세요!' },
+    { id: 9, content: '안녕하!!세요!' },
+    { id: 0, content: '안!!녕!!하세요!' },
+    { id: 11, content: '안녕!!하세요!' },
+    { id: 21, content: '안녕하세요!' },
+    { id: 22, content: '안녕하세요!!' },
+    { id: 23, content: '안녕하!!세요!' },
+    { id: 24, content: '안녕!!하세요!' },
+    { id: 25, content: '!!안녕하세요!' },
+    { id: 26, content: '안!!녕하세요!' },
+    { id: 27, content: '안녕!!하세!!요!' },
+    { id: 28, content: '!!안!!녕하세요!' },
+    { id: 29, content: '안녕하!!세요!' },
+    { id: 20, content: '안!!녕!!하세요!' },
+    { id: 211, content: '안녕!!하세요!' },
+  ];
+
+  return (
+    <article css={myTagCss}>
+      <NavigationBar
+        title="태그 관리"
+        rightElement={<GhostButton size="large">완료</GhostButton>}
+      />
+      <ul css={myTagItemListCss}>
+        {tags.map(tag => (
+          <MyTagItem
+            key={tag.id}
+            tag={tag}
+            onDelete={id => {
+              id;
+            }}
+          />
+        ))}
+      </ul>
+      {/* TODO: CTAButton PR 적용되면 업데이트 예정  */}
+      <CTAButton css={myTagRegisterCss}>태그등록</CTAButton>
+    </article>
+  );
 }
 
-const myTagCss = css``;
+const myTagCss = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
+const myTagItemListCss = css`
+  margin-top: 20px;
+  flex: 1;
+  overflow-y: scroll;
+`;
+const myTagRegisterCss = css`
+  position: absolute;
+  bottom: 34px;
+`;

--- a/src/pages/my/tag/index.tsx
+++ b/src/pages/my/tag/index.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
-import { CTAButton, GhostButton } from '~/components/common/Button';
+import { GhostButton } from '~/components/common/Button';
+import { CTABottomButton } from '~/components/common/Button/CTABottomButton';
 import NavigationBar from '~/components/common/NavigationBar';
 import MyTagItem from '~/components/my/tag/MyTagItem';
 
@@ -38,17 +39,11 @@ export default function MyTag() {
       />
       <ul css={myTagItemListCss}>
         {tags.map(tag => (
-          <MyTagItem
-            key={tag.id}
-            tag={tag}
-            onDelete={id => {
-              id;
-            }}
-          />
+          <MyTagItem key={tag.id} tag={tag} />
         ))}
       </ul>
       {/* TODO: CTAButton PR 적용되면 업데이트 예정  */}
-      <CTAButton css={myTagRegisterCss}>태그등록</CTAButton>
+      <CTABottomButton>태그등록</CTABottomButton>
     </article>
   );
 }
@@ -63,8 +58,4 @@ const myTagItemListCss = css`
   margin-top: 20px;
   flex: 1;
   overflow-y: scroll;
-`;
-const myTagRegisterCss = css`
-  position: absolute;
-  bottom: 34px;
 `;

--- a/src/remotes/tag.d.ts
+++ b/src/remotes/tag.d.ts
@@ -7,3 +7,5 @@ interface TagInterface {
   createdDatetime: string;
   updatedDatetime: string;
 }
+
+type TagType = Pick<TagInterface, 'content' | 'id'>;


### PR DESCRIPTION
## ⛳️작업 내용
- 마이페이지에서 공통을로 사용되는 `Menu` 컴포넌트 추가했습니다.
  - 살펴본 결과 Menu에서는 label과 오른쪽 IconButton이외의 사용을 못보아서 flex & space-between를 이용해서 개발했습니다.
- 마이패이지의 태그 관리 페이지 개발하였습니다.
 - `Menu`를 이용해서 `MyTagItem`을 개발하여 사용했습니다.

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 🚨 주의점
- **디자이너분들과 협의 이후 좌우 padding 16px 된 divider 적용하는것으로 논의되었습니다**
- CTAButton 머지되면 추가 예정입니다.
- 혀바닥 Modal은 추후 개발해서 적용하겠습니다.
  - 테그 등록 모달
  - #138 

## 📸스크린샷
<img width="629" alt="image" src="https://user-images.githubusercontent.com/59507527/167268098-554d0710-75ee-4148-9403-3044613369ad.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
### Menu 컴포넌트
- label과 오른쪽 IconButton 넣어주시면됩니다!
```tsx
<Menu
  label={tag.content}
  rightElement={
    <IconButton
      onClick={() => {
        onDelete(tag.id);
      }}
      iconName="RemoveCircleIcon"
      light
    />
  }
/>
```
### MyTagItem 컴포넌트
```tsx
<MyTagItem
  key={tag.id}
  tag={tag}
  onDelete={id => {
    id;
  }}
/>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
