### PR TITLE
홈 화면 - 네비게이션 바 + 태그 추가 개발 w/ 공용 훅

### DIFF
--- a/src/components/TagForm/index.tsx
+++ b/src/components/TagForm/index.tsx
@@ -7,7 +7,8 @@ import useInput from '~/hooks/common/useInput';
 import AppliedTags from './AppliedTags';
 import RegisteredTagList from './RegisteredTagList';
 
-export default function TagFrom({
+// NOTE: Props들을 컴포넌트내에서 관리할 수도 있지 않을까
+export default function TagForm({
   applyedTags = [],
   registeredTags = [],
   onSave,

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -6,16 +6,23 @@ import useInternalRouter, { RouterPathType } from '~/hooks/common/useInternalRou
 
 interface NavigationBarProps {
   backLink?: RouterPathType;
+  backLinkScrollOption?: boolean;
   title?: string;
   rightElement?: ReactElement;
 }
 
-export default function NavigationBar({ backLink, title, rightElement }: NavigationBarProps) {
+export default function NavigationBar({
+  backLink,
+  backLinkScrollOption = true,
+  title,
+  rightElement,
+}: NavigationBarProps) {
   const router = useInternalRouter();
 
+  // NOTE: 1. router option을 전체적으로 받을 수 있게? 2. onClickBackButton callback을 받을 수 있게?
   const onClickBackButton = () => {
     if (backLink) {
-      router.push(backLink);
+      router.push(backLink, undefined, { scroll: backLinkScrollOption });
       return;
     }
     router.back();

--- a/src/components/home/AppendButton.tsx
+++ b/src/components/home/AppendButton.tsx
@@ -52,7 +52,7 @@ const buttonCss = (theme: Theme) => css`
   background-color: ${theme.color.primary};
   border-radius: 50%;
   color: ${theme.color.gray06};
-  z-index: 9999;
+  z-index: 900;
 `;
 
 const backdropCss = (theme: Theme) => css`
@@ -62,7 +62,7 @@ const backdropCss = (theme: Theme) => css`
   width: 100vw;
   height: 100vh;
   background-color: ${theme.color.dim03};
-  z-index: 1000;
+  z-index: 800;
 `;
 
 const buttonRotateVariants: Variants = {

--- a/src/components/home/HomeNavigationBar.tsx
+++ b/src/components/home/HomeNavigationBar.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { css, Theme } from '@emotion/react';
 
 import { FilterIcon, SettingsIcon } from '../common/icons';
@@ -6,7 +7,11 @@ import InternalLink from '../common/InternalLink';
 export default function HomeNavigationBar() {
   return (
     <nav css={navCss}>
-      <FilterIcon css={iconCss} />
+      <Link href="/?modal=tag" as="/tag" scroll={false}>
+        <a>
+          <FilterIcon css={iconCss} />
+        </a>
+      </Link>
       <InternalLink href="/my">
         <a>
           <SettingsIcon css={iconCss} />
@@ -16,9 +21,12 @@ export default function HomeNavigationBar() {
   );
 }
 
-const navCss = css`
+const navCss = (theme: Theme) => css`
+  position: sticky;
+  top: 0;
   width: 100%;
   height: 44px;
+  background-color: ${theme.color.background};
   display: flex;
   justify-content: flex-end;
   align-items: center;

--- a/src/components/home/HomeNavigationBar.tsx
+++ b/src/components/home/HomeNavigationBar.tsx
@@ -1,0 +1,31 @@
+import { css, Theme } from '@emotion/react';
+
+import { FilterIcon, SettingsIcon } from '../common/icons';
+import InternalLink from '../common/InternalLink';
+
+export default function HomeNavigationBar() {
+  return (
+    <nav css={navCss}>
+      <FilterIcon css={iconCss} />
+      <InternalLink href="/my">
+        <a>
+          <SettingsIcon css={iconCss} />
+        </a>
+      </InternalLink>
+    </nav>
+  );
+}
+
+const navCss = css`
+  width: 100%;
+  height: 44px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 4px;
+`;
+
+const iconCss = (theme: Theme) => css`
+  margin: 10px;
+  color: ${theme.color.gray05};
+`;

--- a/src/components/home/TagFormRouteAsModal.tsx
+++ b/src/components/home/TagFormRouteAsModal.tsx
@@ -1,0 +1,35 @@
+import { css, Theme } from '@emotion/react';
+
+import PortalWrapper from '~/components/common/PortalWrapper';
+import usePreventScroll from '~/hooks/common/usePreventScroll';
+import useQueryParam from '~/hooks/common/useRouterQuery';
+import TagPage from '~/pages/tag';
+
+export default function TagFormRouteAsModal() {
+  const query = useQueryParam('modal', String);
+
+  usePreventScroll(Boolean(query));
+
+  return (
+    <PortalWrapper isShowing={Boolean(query)}>
+      <div css={wrapperCss}>
+        <TagPage />
+      </div>
+    </PortalWrapper>
+  );
+}
+
+const wrapperCss = (theme: Theme) => css`
+  position: fixed;
+  top: 0;
+  /* 가로 가운데 정렬 */
+  left: 50%;
+  transform: translateX(-50%);
+
+  width: 100%;
+  max-width: ${theme.size.maxWidth};
+  height: 100vh;
+  background-color: ${theme.color.background};
+  padding: ${theme.size.layoutPadding};
+  z-index: 1000;
+`;

--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { UrlObject } from 'url';
 
-export type RouterPathType = `/` | '/test' | '/add/link' | '/add/text' | '/add/image';
+export type RouterPathType = `/` | '/test' | '/add/link' | '/add/text' | '/add/image' | '/my';
 
 export default function useInternalRouter() {
   const router = useRouter();

--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -2,7 +2,15 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { UrlObject } from 'url';
 
-export type RouterPathType = `/` | '/test' | '/add/link' | '/add/text' | '/add/image' | '/my';
+export type RouterPathType =
+  | `/`
+  | '/test'
+  | '/add/link'
+  | '/add/text'
+  | '/add/image'
+  | '/add/tag'
+  | '/my'
+  | '/my/tag';
 
 export default function useInternalRouter() {
   const router = useRouter();

--- a/src/hooks/common/usePreventScroll/index.ts
+++ b/src/hooks/common/usePreventScroll/index.ts
@@ -1,0 +1,1 @@
+export { default } from './usePreventScroll';

--- a/src/hooks/common/usePreventScroll/usePreventScroll.ts
+++ b/src/hooks/common/usePreventScroll/usePreventScroll.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export default function usePreventScroll(condition: boolean = true) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (condition) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = 'unset';
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [condition]);
+}

--- a/src/hooks/common/useRouterQuery/index.ts
+++ b/src/hooks/common/useRouterQuery/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useRouterQuery';

--- a/src/hooks/common/useRouterQuery/useRouterQuery.ts
+++ b/src/hooks/common/useRouterQuery/useRouterQuery.ts
@@ -1,0 +1,19 @@
+import { useRouter } from 'next/router';
+
+function useQueryParam(key: string): string | string[] | undefined;
+
+function useQueryParam<T>(key: string, parser: (value: string | string[]) => T): T | undefined;
+
+function useQueryParam<T>(
+  key: string,
+  parser?: (value: string | string[]) => T
+): (string | string[] | T) | undefined {
+  const { query } = useRouter();
+  const result = query[key];
+
+  if (result === undefined) return undefined;
+  if (parser) return parser(result);
+  return result;
+}
+
+export default useQueryParam;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,7 +34,6 @@ const layoutCss = (theme: Theme) => css`
   background: ${theme.color.background};
   max-width: ${theme.size.maxWidth};
   width: 100%;
-  height: 100%;
   margin: 0 auto;
   padding: ${theme.size.layoutPadding};
 `;

--- a/src/pages/add/tag.tsx
+++ b/src/pages/add/tag.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import NavigationBar from '~/components/common/NavigationBar';
-import TagFrom from '~/components/TagForm';
+import TagForm from '~/components/TagForm';
 import { useAppliedTags } from '~/store/AppliedTags';
 
 export default function AddTag() {
@@ -19,7 +19,7 @@ export default function AddTag() {
   return (
     <article css={addTagCss}>
       <NavigationBar title="영감 추가" />
-      <TagFrom applyedTags={tags} registeredTags={tagsB} onSave={addTag} onRemove={removeTag} />
+      <TagForm applyedTags={tags} registeredTags={tagsB} onSave={addTag} onRemove={removeTag} />
     </article>
   );
 }

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import NavigationBar from '~/components/common/NavigationBar';
-import TagFrom from '~/components/TagForm';
+import TagForm from '~/components/TagForm';
 import { useToast } from '~/store/Toast';
 
 export interface EditTagProps {
@@ -42,7 +42,7 @@ export default function EditTag({ contentId, contentTags }: EditTagProps) {
   return (
     <article css={editTagCss}>
       <NavigationBar title="영감 편집" />
-      <TagFrom
+      <TagForm
         applyedTags={contentTags}
         registeredTags={tagsB}
         onSave={saveTag}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import AppendButton from '~/components/home/AppendButton';
 import ContentThumbnail from '~/components/home/ContentThumbnail';
 import HomeNavigationBar from '~/components/home/HomeNavigationBar';
+import TagFormRouteAsModal from '~/components/home/TagFormRouteAsModal';
 
 export default function Root() {
   return (
@@ -10,6 +11,81 @@ export default function Root() {
       <HomeNavigationBar />
       <article>
         <section css={thumbnailWrapperCss}>
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
           <ContentThumbnail
             type="TEXT"
             content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
@@ -34,6 +110,7 @@ export default function Root() {
         </section>
         <AppendButton />
       </article>
+      <TagFormRouteAsModal />
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,35 +2,39 @@ import { css } from '@emotion/react';
 
 import AppendButton from '~/components/home/AppendButton';
 import ContentThumbnail from '~/components/home/ContentThumbnail';
+import HomeNavigationBar from '~/components/home/HomeNavigationBar';
 
 export default function Root() {
   return (
-    <article>
-      <section css={thumbnailWrapperCss}>
-        <ContentThumbnail
-          type="TEXT"
-          content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
-          tags={[]}
-        />
-        <ContentThumbnail
-          type="IMAGE"
-          content="https://avatars.githubusercontent.com/u/26461307?v=4"
-          tags={[]}
-        />
-        <ContentThumbnail
-          type="TEXT"
-          content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
-          tags={TEST_TAGS}
-        />
-        <ContentThumbnail
-          type="IMAGE"
-          content="https://avatars.githubusercontent.com/u/26461307?v=4"
-          tags={TEST_TAGS}
-        />
-        <ContentThumbnail type="TEXT" content="asdf" tags={[]} />
-      </section>
-      <AppendButton />
-    </article>
+    <>
+      <HomeNavigationBar />
+      <article>
+        <section css={thumbnailWrapperCss}>
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="IMAGE"
+            content="https://avatars.githubusercontent.com/u/26461307?v=4"
+            tags={[]}
+          />
+          <ContentThumbnail
+            type="TEXT"
+            content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Laborum, similique quisquam. Inventore iure excepturi, accusamus quae repudiandae, aspernatur praesentium, consequatur quidem modi a sit rerum molestias iusto quaerat vitae perspiciatis."
+            tags={TEST_TAGS}
+          />
+          <ContentThumbnail
+            type="IMAGE"
+            content="https://avatars.githubusercontent.com/u/26461307?v=4"
+            tags={TEST_TAGS}
+          />
+          <ContentThumbnail type="TEXT" content="asdf" tags={[]} />
+        </section>
+        <AppendButton />
+      </article>
+    </>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,11 @@
+import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
 import AppendButton from '~/components/home/AppendButton';
 import ContentThumbnail from '~/components/home/ContentThumbnail';
 import HomeNavigationBar from '~/components/home/HomeNavigationBar';
-import TagFormRouteAsModal from '~/components/home/TagFormRouteAsModal';
+
+const TagFormRouteAsModal = dynamic(() => import('~/components/home/TagFormRouteAsModal'));
 
 export default function Root() {
   return (

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,6 +1,6 @@
 import NavigationBar from '~/components/common/NavigationBar';
 import TagForm from '~/components/TagForm';
-import { useAppliedTags } from '~/store/AppliedTags';
+import { useFilteredTags } from '~/store/FilteredTags';
 
 // TODO: 비동기 요청으로 대체
 const mockTags: TagType[] = [
@@ -13,12 +13,17 @@ const mockTags: TagType[] = [
 ];
 
 export default function TagPage() {
-  const { tags, removeTag, addTag } = useAppliedTags();
+  const { filteredTags, addTag, removeTag } = useFilteredTags({});
 
   return (
     <article>
       <NavigationBar title="태그 추가" backLink="/" backLinkScrollOption={false} />
-      <TagForm applyedTags={tags} registeredTags={mockTags} onSave={addTag} onRemove={removeTag} />
+      <TagForm
+        applyedTags={filteredTags}
+        registeredTags={mockTags}
+        onSave={addTag}
+        onRemove={removeTag}
+      />
     </article>
   );
 }

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,0 +1,24 @@
+import NavigationBar from '~/components/common/NavigationBar';
+import TagForm from '~/components/TagForm';
+import { useAppliedTags } from '~/store/AppliedTags';
+
+// TODO: 비동기 요청으로 대체
+const mockTags: TagType[] = [
+  { id: 1, content: 'hi hihi hi hi hi hi hi ' },
+  { id: 2, content: 'h2' },
+  { id: 3, content: 'h3' },
+  { id: 4, content: 'h4' },
+  { id: 5, content: 'h5' },
+  { id: 6, content: 'h6' },
+];
+
+export default function TagPage() {
+  const { tags, removeTag, addTag } = useAppliedTags();
+
+  return (
+    <article>
+      <NavigationBar title="태그 추가" backLink="/" backLinkScrollOption={false} />
+      <TagForm applyedTags={tags} registeredTags={mockTags} onSave={addTag} onRemove={removeTag} />
+    </article>
+  );
+}

--- a/src/store/FilteredTags/filteredTagsStates.ts
+++ b/src/store/FilteredTags/filteredTagsStates.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const filteredTagsState = atom<TagType[]>({
+  key: 'filteredTagsState',
+  default: [],
+});

--- a/src/store/FilteredTags/index.ts
+++ b/src/store/FilteredTags/index.ts
@@ -1,0 +1,2 @@
+export { filteredTagsState } from './filteredTagsStates';
+export { useFilteredTags } from './useFilteredTags';

--- a/src/store/FilteredTags/useFilteredTags.ts
+++ b/src/store/FilteredTags/useFilteredTags.ts
@@ -1,0 +1,29 @@
+import { useRecoilState } from 'recoil';
+
+import { filteredTagsState } from './filteredTagsStates';
+
+interface UseFilteredTagsProps {
+  onRejectedAddingTag?: VoidFunction;
+}
+
+export function useFilteredTags({ onRejectedAddingTag = () => {} }: UseFilteredTagsProps) {
+  const [filteredTags, setFilteredTags] = useRecoilState(filteredTagsState);
+
+  const hasTag = (tag: TagType) => {
+    return Boolean(filteredTags.find(_tag => _tag.id === tag.id));
+  };
+
+  const addTag = (tag: TagType) => {
+    if (hasTag(tag)) {
+      onRejectedAddingTag();
+      return;
+    }
+    setFilteredTags(prevTags => [...prevTags, tag]);
+  };
+
+  const removeTag = (id: number) => {
+    setFilteredTags(prevTags => prevTags.filter(_tag => _tag.id !== id));
+  };
+
+  return { filteredTags, hasTag, addTag, removeTag };
+}

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -41,10 +41,5 @@ const globalCss = (theme: Theme) => css`
         display: none !important;
       }
     }
-
-    body,
-    #__next {
-      height: 100vh;
-    }
   }
 `;


### PR DESCRIPTION
## ⛳️작업 내용

작업 기간이 기간이니,,, 나눠서 개발할 수도 있었지만 개발 진척도를 위해 뭉쳐서 개발했슴다

**홈화면에 대한 부분**

- `/tag` route를 홈 화면에서 사용되는 태그 관리 route로 사용했습니다 + Route as modal로써 사용했습니다
- `components/home/TagFormRouteAsModal` 에서 query param을 기준으로 모달을 보여주었습니다. (children으로 page 컴포넌트를 렌더링합니다)

**공통되는 부분**

- `TagForm`이 `TagFrom`으로 돼 있어서 오타 수정했슴다
- 자료형 보장을 함께 할 수 있는 `useQueryParam` 훅을 개발했습니다
- Route as modal등에서 body의 스크롤 방지를 위한 `usePreventScroll` 훅을 개발했슴니다

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

- useQueryParam

```ts
const foo = useQueryParam('foo'); // string | undefined
const num = useQueryParam('num', Number); // number | undefined
const barNum = useQueryParam('foo-num', Number) ?? -1; // number
```

- usePreventScroll

```ts
const foo = useQueryParam('foo');

usePreventScroll(Boolean(foo)); // 안에 조건을 넣어주면 됨니다
```

## 📎공유

- 리팩토링? 수정? 가능하다고 생각되는 부분은 `NOTE:` 달아놨어용
- 현재 홈 화면 태그 추가에서도 전역 상태인 `appliedTags`를 사용하고 있어요. 영감 추가나 편집시에 태그가 비어있어야 한다면 특정 라우트 진입하거나, 언마운트시에 리셋하는 로직을 추가해야합니다!! ([리코일 리셋 훅](https://recoiljs.org/ko/docs/api-reference/core/useResetRecoilState/))


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
