### PR TITLE
singup/email-verified CTABottomButton 적용 및 CTABottomButton 업데이트

### DIFF
--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -44,9 +44,12 @@ const ctaBottomButtonCss = ({
   bottom: string;
 }) => css`
   position: absolute;
-  left: 0;
+  left: 50%;
+  transform: translateX(-50%);
   bottom: ${bottom};
+
   padding: ${isIos ? `8px 16px 0 16px` : `8px 16px`};
   background: ${theme.color.background};
   width: 100%;
+  max-width: ${theme.size.maxWidth};
 `;

--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -23,9 +23,9 @@ interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {
  * ```
  */
 export function CTABottomButton(props: CTABottomButtonProps) {
+  const { children, bottom = '0', ...rest } = props;
   const { isIos } = useUserAgent();
   const theme = useTheme();
-  const { children, bottom = '0', ...rest } = props;
 
   return (
     <div css={ctaBottomButtonCss({ theme, isIos: isIos(), bottom })}>
@@ -35,12 +35,12 @@ export function CTABottomButton(props: CTABottomButtonProps) {
 }
 
 const ctaBottomButtonCss = ({
-  isIos,
   theme,
+  isIos,
   bottom,
 }: {
-  isIos: boolean;
   theme: Theme;
+  isIos: boolean;
   bottom: string;
 }) => css`
   position: absolute;

--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -5,51 +5,21 @@ import { useUserAgent } from '~/hooks/common/useUserAgent';
 
 import { CTAButton } from './CTAButton';
 
-interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {
-  /**
-   * css bottom 속성입니다.
-   *
-   * @default 0
-   */
-  bottom?: string;
-}
+interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {}
 
-/**
- * {@link CTAButton}을 확장하여, absoulte bottom을 갖는 컴포넌트입니다.
- *
- * @example ```tsx
- * <CTABottomButton>기본 버튼</CTABottomButton>
- * <CTABottomButton bottom="12px">bottom 12px 버튼</CTABottomButton>
- * ```
- */
 export function CTABottomButton(props: CTABottomButtonProps) {
-  const { children, bottom = '0', ...rest } = props;
+  const { children, ...rest } = props;
   const { isIos } = useUserAgent();
   const theme = useTheme();
 
   return (
-    <div css={ctaBottomButtonCss({ theme, isIos: isIos(), bottom })}>
+    <div css={ctaBottomButtonCss({ theme, isIos: isIos() })}>
       <CTAButton {...rest}>{children}</CTAButton>
     </div>
   );
 }
 
-const ctaBottomButtonCss = ({
-  theme,
-  isIos,
-  bottom,
-}: {
-  theme: Theme;
-  isIos: boolean;
-  bottom: string;
-}) => css`
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: ${bottom};
-
-  padding: ${isIos ? `8px 16px 0 16px` : `8px 16px`};
+const ctaBottomButtonCss = ({ theme, isIos }: { theme: Theme; isIos: boolean }) => css`
+  padding: ${isIos ? `8px 0 0 0` : `8px 0`};
   background: ${theme.color.background};
-  width: 100%;
-  max-width: ${theme.size.maxWidth};
 `;

--- a/src/components/common/Button/CTABottomButton.tsx
+++ b/src/components/common/Button/CTABottomButton.tsx
@@ -5,21 +5,48 @@ import { useUserAgent } from '~/hooks/common/useUserAgent';
 
 import { CTAButton } from './CTAButton';
 
-interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {}
+interface CTABottomButtonProps extends ComponentProps<typeof CTAButton> {
+  /**
+   * css bottom 속성입니다.
+   *
+   * @default 0
+   */
+  bottom?: string;
+}
 
+/**
+ * {@link CTAButton}을 확장하여, absoulte bottom을 갖는 컴포넌트입니다.
+ *
+ * @example ```tsx
+ * <CTABottomButton>기본 버튼</CTABottomButton>
+ * <CTABottomButton bottom="12px">bottom 12px 버튼</CTABottomButton>
+ * ```
+ */
 export function CTABottomButton(props: CTABottomButtonProps) {
   const { isIos } = useUserAgent();
   const theme = useTheme();
-  const { children, ...rest } = props;
+  const { children, bottom = '0', ...rest } = props;
 
   return (
-    <div css={ctaBottomButtonCss(isIos(), theme)}>
+    <div css={ctaBottomButtonCss({ theme, isIos: isIos(), bottom })}>
       <CTAButton {...rest}>{children}</CTAButton>
     </div>
   );
 }
 
-const ctaBottomButtonCss = (isIos: boolean, theme: Theme) => css`
-  padding: ${isIos ? `8px 0 0 0` : `8px 0`};
+const ctaBottomButtonCss = ({
+  isIos,
+  theme,
+  bottom,
+}: {
+  isIos: boolean;
+  theme: Theme;
+  bottom: string;
+}) => css`
+  position: absolute;
+  left: 0;
+  bottom: ${bottom};
+  padding: ${isIos ? `8px 16px 0 16px` : `8px 16px`};
   background: ${theme.color.background};
+  width: 100%;
 `;

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,4 +1,5 @@
 export { default } from './Button';
+export { CTABottomButton } from './CTABottomButton';
 export { CTAButton } from './CTAButton';
 export { FilledButton } from './FilledButton';
 export { GhostButton } from './GhostButton';

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -1,6 +1,6 @@
 import { css, Theme } from '@emotion/react';
 
-import { CTAButton } from '~/components/common/Button';
+import { CTABottomButton } from '~/components/common/Button';
 import CheckList from '~/components/common/CheckList';
 import NavigationBar from '~/components/common/NavigationBar';
 import TextField from '~/components/common/TextField';
@@ -50,7 +50,7 @@ export default function SignUpEmailVerified() {
             </CheckList>
           </div>
         </fieldset>
-        <CTAButton type={'submit'}>Start Tang!</CTAButton>
+        <CTABottomButton type={'submit'}>Start Tang!</CTABottomButton>
       </form>
     </article>
   );

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -15,7 +15,7 @@ export default function SignUpEmailVerified() {
     <article css={containerCss}>
       <NavigationBar title={'회원가입'} />
       <p css={introTextWrapper}>마지막 단계입니다!</p>
-      <form>
+      <form css={formCss}>
         <fieldset css={fieldSetCss}>
           <TextField
             label={'닉네임'}
@@ -60,7 +60,7 @@ const containerCss = css`
   display: flex;
   flex-direction: column;
 
-  height: 100%;
+  height: 100vh;
 `;
 
 const introTextWrapper = (theme: Theme) => css`
@@ -73,10 +73,18 @@ const introTextWrapper = (theme: Theme) => css`
   margin-bottom: 32px;
 `;
 
+const formCss = css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
 const fieldSetCss = css`
   display: flex;
   flex-direction: column;
   gap: 16px; // (original 36px) - (label height 20px)
+
+  flex-grow: 1;
 `;
 
 const checkListWrapperCss = css`

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -15,7 +15,7 @@ export default function SignUpEmailVerified() {
     <article css={containerCss}>
       <NavigationBar title={'회원가입'} />
       <p css={introTextWrapper}>마지막 단계입니다!</p>
-      <form css={formCss}>
+      <form>
         <fieldset css={fieldSetCss}>
           <TextField
             label={'닉네임'}
@@ -73,19 +73,10 @@ const introTextWrapper = (theme: Theme) => css`
   margin-bottom: 32px;
 `;
 
-const formCss = css`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-
-  height: 100%;
-`;
-
 const fieldSetCss = css`
   display: flex;
   flex-direction: column;
   gap: 16px; // (original 36px) - (label height 20px)
-  margin-bottom: 52px;
 `;
 
 const checkListWrapperCss = css`


### PR DESCRIPTION
## ⛳️작업 내용

- ~CTABottomButton에 `absoulte bottom` 속성을 줬어요~
- ~CTABottomButton에 `bottom` 인자를 추가했어요~
- `components/common/Button`에서 import 할 수 있도록 export문을 작성했어요

- `signup/email-verified` route에 CTABottomButton을 적용했어요
  - 기존에 space-between 이용하실려고 작성해두셨던 스타일링은 걷어내봤어요

## 📸스크린샷

![스크린샷 2022-05-09 오전 1 16 48](https://user-images.githubusercontent.com/26461307/167305172-c9194574-3ccd-4851-b6dc-82eae94cf701.png)

## ⚡️사용 방법

은정님께서 작성해주신 내용과 크게 다르지 않게 사용할 수 있슴다

```jsx
<CTABottomButton>기본 버튼</CTABottomButton>
<CTABottomButton bottom="12px">bottom 12px 버튼</CTABottomButton>
```

## 📎 공유

원래 도현님과 말씀나눴던대로 email-verified 페이지에 적용할 생각을 하다, 

아예 바닥에만 붙혀둘 용도인가? 생각이 들어서 적용해봤어요 !!

> 은정님께 말씀드리고 수정했었어야 했는데 죄송합니다 ..

`absoulte` 속성에 대해 제가 파악하지 못한 다른 의미가 있으시면 말씀해주세요 !!!

`CTABottomButton`에서 걷어내고 page내에서도 핸들링 가능하니 편하게 말씀해주시면 좋을 거 같아용 👍 

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
