### PR TITLE
공통 컴포넌트 - Dialog 이미지 대응

### DIFF
--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
-import { motion, Variants } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
-import { defaultEasing, defaultFadeInUpVariants } from '~/constants/motions';
+import { defaultFadeInUpVariants, defaultFadeInVariants } from '~/constants/motions';
 
 export interface DialogProps {
   isShowing?: boolean;
@@ -27,7 +27,7 @@ export default function Dialog({
       <PortalWrapper isShowing={true}>
         <motion.div
           css={dimBackdropCss}
-          variants={backgroundFadeInOutVariants}
+          variants={defaultFadeInVariants}
           initial="initial"
           animate="animate"
           exit="exit"
@@ -95,21 +95,3 @@ const dialogButtonWrapperCss = css`
   width: 100%;
   padding: 16px;
 `;
-
-export const backgroundFadeInOutVariants: Variants = {
-  initial: {
-    opacity: 0,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-  animate: {
-    opacity: 1,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-  exit: {
-    opacity: 0,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-};

--- a/src/components/common/IllustDialog.tsx
+++ b/src/components/common/IllustDialog.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
-import { motion, Variants } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
-import { defaultEasing, defaultFadeInUpVariants } from '~/constants/motions';
+import { defaultFadeInUpVariants, defaultFadeInVariants } from '~/constants/motions';
 
 export interface IllustDialogProps {
   isShowing?: boolean;
@@ -29,7 +29,7 @@ export default function IllustDialog({
       <PortalWrapper isShowing={true}>
         <motion.div
           css={dimBackdropCss}
-          variants={backgroundFadeInOutVariants}
+          variants={defaultFadeInVariants}
           initial="initial"
           animate="animate"
           exit="exit"
@@ -110,21 +110,3 @@ const IllustDialogButtonWrapperCss = css`
   width: 100%;
   padding: 16px;
 `;
-
-export const backgroundFadeInOutVariants: Variants = {
-  initial: {
-    opacity: 0,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-  animate: {
-    opacity: 1,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-  exit: {
-    opacity: 0,
-    transition: { duration: 0.2, ease: defaultEasing },
-    willChange: 'opacity',
-  },
-};

--- a/src/components/common/IllustDialog.tsx
+++ b/src/components/common/IllustDialog.tsx
@@ -5,16 +5,18 @@ import { motion, Variants } from 'framer-motion';
 import PortalWrapper from '~/components/common/PortalWrapper';
 import { defaultEasing, defaultFadeInUpVariants } from '~/constants/motions';
 
-export interface DialogProps {
+export interface IllustDialogProps {
   isShowing?: boolean;
+  image: string;
   actionButtons: ReactNode;
 }
 
-export default function Dialog({
+export default function IllustDialog({
   isShowing,
+  image,
   children,
   actionButtons,
-}: PropsWithChildren<DialogProps>) {
+}: PropsWithChildren<IllustDialogProps>) {
   const [isSSR, setIsSSR] = useState(true);
 
   useEffect(() => {
@@ -32,9 +34,12 @@ export default function Dialog({
           animate="animate"
           exit="exit"
         >
-          <motion.div css={dialogCss} variants={defaultFadeInUpVariants}>
-            <div css={dialogContentWrapperCss}>{children}</div>
-            <div css={dialogButtonWrapperCss}>{actionButtons}</div>
+          <motion.div css={IllustDialogCss} variants={defaultFadeInUpVariants}>
+            <div css={IllustContentContainerCss}>
+              <img src={image} alt="일러스트 이미지" css={IllustImageCss} />
+              <div css={IllustDialogContentWrapperCss}>{children}</div>
+            </div>
+            <div css={IllustDialogButtonWrapperCss}>{actionButtons}</div>
           </motion.div>
         </motion.div>
       </PortalWrapper>
@@ -49,7 +54,7 @@ const dimBackdropCss = (theme: Theme) => css`
   align-items: center;
   justify-content: center;
 
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100vw;
@@ -61,12 +66,26 @@ const dimBackdropCss = (theme: Theme) => css`
   overflow: hidden;
 `;
 
-const dialogCss = (theme: Theme) => css`
-  position: relative;
+const IllustContentContainerCss = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-end;
+  gap: 16px;
+  margin-top: -88px;
+  margin-bottom: 24px;
+`;
+
+const IllustImageCss = css`
+  width: 240px;
+  height: 160px;
+`;
+
+const IllustDialogCss = (theme: Theme) => css`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  top: 288px;
 
   width: 311px;
   min-height: 200px;
@@ -75,19 +94,15 @@ const dialogCss = (theme: Theme) => css`
   border-radius: ${theme.borderRadius.default};
 `;
 
-const dialogContentWrapperCss = (theme: Theme) => css`
-  white-space: pre;
+const IllustDialogContentWrapperCss = (theme: Theme) => css`
   font-weight: ${theme.font.weight.bold};
-  font-style: normal;
   color: ${theme.color.gray05};
   font-size: 16px;
   line-height: 150%;
   text-align: center;
-
-  margin: 24px 16px;
 `;
 
-const dialogButtonWrapperCss = css`
+const IllustDialogButtonWrapperCss = css`
   display: flex;
   flex-direction: row;
   gap: 16px;

--- a/src/pages/test/dialog.tsx
+++ b/src/pages/test/dialog.tsx
@@ -1,0 +1,19 @@
+import { FilledButton } from '~/components/common/Button';
+import IllustDialog from '~/components/common/IllustDialog';
+
+export default function DialogTestPage() {
+  return (
+    <IllustDialog
+      isShowing={true}
+      image={'https://i.imgur.com/LbBxqvv.png'}
+      actionButtons={
+        <>
+          <FilledButton colorType="light">취소</FilledButton>
+          <FilledButton colorType="dark">다시 인증</FilledButton>
+        </>
+      }
+    >
+      정말 로그아웃 하시겠어요?
+    </IllustDialog>
+  );
+}


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- IllustDialog를 만들었습니다.
  - 원래는 Dialog에서 대응하려고 했으나, 레이아웃 변경이 커서 새로운 컴포넌트로 분리하는게 낫겠다는 판단을 내렸습니다.
  - 이미지 소스는 240x160 이여야합니다.
- 추후 일러스트 같은 static 이미지를 어디에 저장할 것인지 의논해봐야 할 것 같아요

테스트 링크: https://1b761a72.ygt.pages.dev/test/dialog

Closed #144

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

<img width="467" alt="image" src="https://user-images.githubusercontent.com/6638675/167536411-c040c771-b6a4-454c-a637-2113dddfae30.png">


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
