### PR TITLE
useIntersectionObserver hook 개발

### DIFF
--- a/src/hooks/common/useIntersectionObserver/index.test.ts
+++ b/src/hooks/common/useIntersectionObserver/index.test.ts
@@ -1,0 +1,7 @@
+import Default from './index';
+
+describe('hooks/common/useIntersectionObserver', () => {
+  it('should defined with default', () => {
+    expect(Default).toBeDefined();
+  });
+});

--- a/src/hooks/common/useIntersectionObserver/index.ts
+++ b/src/hooks/common/useIntersectionObserver/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useIntersectionObserver';

--- a/src/hooks/common/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver/useIntersectionObserver.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+interface UseIntersectionObserverProps extends IntersectionObserverInit {
+  onIntersect: IntersectionObserverCallback;
+}
+
+export default function useIntersectionObserver({
+  onIntersect,
+  root = null,
+  rootMargin = '0px',
+  threshold = 0,
+}: UseIntersectionObserverProps) {
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer: IntersectionObserver = new IntersectionObserver(onIntersect, {
+      root,
+      rootMargin,
+      threshold,
+    });
+    observer.observe(target);
+
+    return () => observer.unobserve(target);
+  }, [onIntersect, root, rootMargin, target, threshold]);
+
+  return { setTarget };
+}


### PR DESCRIPTION
## ⛳️작업 내용

Infinite Scroll에 사용될 custom hook을 개발하였습니당

## 📸스크린샷

## ⚡️사용 방법

```jsx
function Foo() {

  const { setTarget } = useIntersectionObserver({
    onIntersect: ([{ isIntersecting }]) => {
      if (isIntersecting) console.log('intersect');
    },
  });

  return (
        <section>
          { 리스트렌더링 }

          <div ref={setTarget}></div>
        </section>
  );
}
```

현재는 이렇게 `IntersectionOberverCallback`을 주입하는 형태로 사용할 수 있어요!

이렇게 될 시 intersect 옵션에 따른 처리가 가능하지만, 코드가 다소 산만해지는 거 같다고 생각이 들어서,

주입하는 `onIntersect` 콜백을 훅 내부에서 `isIntersect true` 일 시에만 실행하는 방향으로 바꿀까 생각이 듭니다!

다른 분들은 인터섹션 옵저버 어떻게 사용하신 경험이 있으신지 궁금해요 !

## 📎레퍼런스

- [부끄럽지만 제 블로그 글입니다 - 내가 인터섹션 옵저버 사용하는 방법](https://www.hyesungoh.xyz/usisngIntersectionObserverMyWay)
