### PR TITLE
레이아웃 - 모바일 url 바에 따른 100vh 자동 조절

### DIFF
--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -51,7 +51,7 @@ const dimBackdropCss = (theme: Theme) => css`
   left: 0;
 
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 
   background-color: ${theme.color.dim03};
 
@@ -62,7 +62,7 @@ const MARGIN_TOP = 54;
 const MIN_HIEGHT = 208;
 const contentWrapperCss = (theme: Theme) => css`
   position: absolute;
-  top: 100vh;
+  top: calc(var(--vh, 1vh) * 100);
   transform: translateY(-100%);
 
   width: 100%;

--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -51,7 +51,7 @@ const dimBackdropCss = (theme: Theme) => css`
   left: 0;
 
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
 
   background-color: ${theme.color.dim03};
 
@@ -62,7 +62,7 @@ const MARGIN_TOP = 54;
 const MIN_HIEGHT = 208;
 const contentWrapperCss = (theme: Theme) => css`
   position: absolute;
-  top: calc(var(--vh, 1vh) * 100);
+  top: 100%;
   transform: translateY(-100%);
 
   width: 100%;

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -53,7 +53,7 @@ const dimBackdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 
   background-color: ${theme.color.dim03};
 

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -53,7 +53,7 @@ const dimBackdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
 
   background-color: ${theme.color.dim03};
 

--- a/src/components/common/IllustDialog.tsx
+++ b/src/components/common/IllustDialog.tsx
@@ -58,7 +58,7 @@ const dimBackdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
 
   background-color: ${theme.color.dim03};
 

--- a/src/components/common/IllustDialog.tsx
+++ b/src/components/common/IllustDialog.tsx
@@ -58,7 +58,7 @@ const dimBackdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 
   background-color: ${theme.color.dim03};
 

--- a/src/components/home/AppendButton.tsx
+++ b/src/components/home/AppendButton.tsx
@@ -61,7 +61,7 @@ const backdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   background-color: ${theme.color.dim03};
   z-index: 800;
 `;

--- a/src/components/home/AppendButton.tsx
+++ b/src/components/home/AppendButton.tsx
@@ -61,7 +61,7 @@ const backdropCss = (theme: Theme) => css`
   top: 0;
   left: 0;
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
   background-color: ${theme.color.dim03};
   z-index: 800;
 `;

--- a/src/components/home/TagFormRouteAsModal.tsx
+++ b/src/components/home/TagFormRouteAsModal.tsx
@@ -28,7 +28,7 @@ const wrapperCss = (theme: Theme) => css`
 
   width: 100%;
   max-width: ${theme.size.maxWidth};
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
   background-color: ${theme.color.background};
   padding: ${theme.size.layoutPadding};
   z-index: 1000;

--- a/src/components/home/TagFormRouteAsModal.tsx
+++ b/src/components/home/TagFormRouteAsModal.tsx
@@ -28,7 +28,7 @@ const wrapperCss = (theme: Theme) => css`
 
   width: 100%;
   max-width: ${theme.size.maxWidth};
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   background-color: ${theme.color.background};
   padding: ${theme.size.layoutPadding};
   z-index: 1000;

--- a/src/hooks/common/useWindowSize.ts
+++ b/src/hooks/common/useWindowSize.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+interface Size {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+export function useWindowSize(): Size {
+  const [windowSize, setWindowSize] = useState<Size>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -43,13 +43,14 @@ function Layout({ children }: PropsWithChildren<{}>) {
 
   useEffect(() => {
     vh = window.innerHeight * 0.01;
-    document && document.documentElement.style.setProperty('--vh', `${vh}px`);
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
   }, [windowSize.height]);
 
   return <div css={layoutCss}>{children}</div>;
 }
 
 const layoutCss = (theme: Theme) => css`
+  height: calc(var(--vh, 1vh) * 100);
   background: ${theme.color.background};
   max-width: ${theme.size.maxWidth};
   width: 100%;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 import { AppProps } from 'next/app';
 import { css, Theme, ThemeProvider } from '@emotion/react';
 import { QueryClientProvider } from 'react-query';
@@ -6,6 +6,7 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 
 import ToastSection from '~/components/common/ToastSection';
+import { useWindowSize } from '~/hooks/common/useWindowSize';
 import { queryClient } from '~/libs/api/queryClient';
 import { UserProvider } from '~/store/User/UserProvider';
 import GlobalStyle from '~/styles/GlobalStyle';
@@ -35,7 +36,16 @@ export default function App({ Component, pageProps }: AppProps) {
  *
  * `_app`에서만 사용되는 컴포넌트이기에, 인라인으로 작성되었습니다.
  */
+let vh = 0;
+
 function Layout({ children }: PropsWithChildren<{}>) {
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    vh = window.innerHeight * 0.01;
+    document && document.documentElement.style.setProperty('--vh', `${vh}px`);
+  }, [windowSize.height]);
+
   return <div css={layoutCss}>{children}</div>;
 }
 

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -51,7 +51,7 @@ export default function AddImage() {
 const addImageCss = css`
   display: flex;
   flex-direction: column;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
   overflow: hidden;
 `;
 

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -51,7 +51,7 @@ export default function AddImage() {
 const addImageCss = css`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   overflow: hidden;
 `;
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -45,7 +45,7 @@ export default function AddLink() {
 const addLinkCss = css`
   display: flex;
   flex-direction: column;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
   overflow: hidden;
 `;
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -45,7 +45,7 @@ export default function AddLink() {
 const addLinkCss = css`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   overflow: hidden;
 `;
 

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -42,7 +42,7 @@ export default function AddText() {
 const addTextCss = css`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   overflow: hidden;
 `;
 

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -42,7 +42,7 @@ export default function AddText() {
 const addTextCss = css`
   display: flex;
   flex-direction: column;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
   overflow: hidden;
 `;
 

--- a/src/pages/my/tag/index.tsx
+++ b/src/pages/my/tag/index.tsx
@@ -69,7 +69,7 @@ const myTagCss = css`
   position: relative;
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 `;
 const myTagItemListCss = css`
   margin-top: 20px;

--- a/src/pages/my/tag/index.tsx
+++ b/src/pages/my/tag/index.tsx
@@ -69,7 +69,7 @@ const myTagCss = css`
   position: relative;
   display: flex;
   flex-direction: column;
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
 `;
 const myTagItemListCss = css`
   margin-top: 20px;

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -60,7 +60,7 @@ const containerCss = css`
   display: flex;
   flex-direction: column;
 
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 `;
 
 const introTextWrapper = (theme: Theme) => css`

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -60,7 +60,7 @@ const containerCss = css`
   display: flex;
   flex-direction: column;
 
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
 `;
 
 const introTextWrapper = (theme: Theme) => css`


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### [feat: useWindowSize 훅 추가 및 가변 vh 설정](https://github.com/depromeet/11th_7team_web/commit/c9ffe3c0517edc465619c14a0b1b560773203830)

height가 계속 잘리는 걸 계속 눈에 밟혀서 간단하게 작업해보았습니다..
전 항상 이런식으로 적용해왔었는데, 다른 더 좋은 방법 경험해보신 것 있다면 말씀해주세요! :)
useWindowSize 훅을 쓰는 이유는 url바가 자동으로 사라지고 생성되는 환경을 위해서(특히 카카오 인 웹) 적용했습니다!


## 📸스크린샷
![IMG_C002E723EAF9-1](https://user-images.githubusercontent.com/69200669/168142192-50388084-5e23-4185-9249-a6e4a77d362b.jpeg)
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

100vh 대신 `calc(var(--vh, 1vh) * 100)`으로 적어주시면 됩니다.

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
