### PR TITLE
Router Guard 적용 및 Reissue mutation 수정

### DIFF
--- a/src/hooks/api/reissue/useReissueMutation.ts
+++ b/src/hooks/api/reissue/useReissueMutation.ts
@@ -1,4 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
 import { useMutation } from 'react-query';
 
 import { post } from '~/libs/api/client';
@@ -8,11 +7,14 @@ interface ReissueMutationRequest {
 }
 
 interface UseReissueMutationProps {
-  userLogin: ({ accessToken, refreshToken }: { accessToken: string; refreshToken: string }) => void;
-  setIsLoaded: Dispatch<SetStateAction<boolean>>;
+  onSuccess?: (
+    data: AuthTokenResponseInterface,
+    variables: ReissueMutationRequest,
+    context: unknown
+  ) => void | Promise<unknown>;
 }
 
-export default function useReissueMutation({ userLogin, setIsLoaded }: UseReissueMutationProps) {
+export default function useReissueMutation({ onSuccess }: UseReissueMutationProps) {
   return useMutation(
     (data: ReissueMutationRequest) =>
       post<AuthTokenResponseInterface>('/v1/reissue', undefined, {
@@ -21,11 +23,7 @@ export default function useReissueMutation({ userLogin, setIsLoaded }: UseReissu
         },
       }),
     {
-      onSuccess: data => {
-        const { accessToken, refreshToken } = data.data;
-        userLogin({ accessToken, refreshToken });
-        setIsLoaded(true);
-      },
+      onSuccess,
     }
   );
 }

--- a/src/hooks/api/reissue/useReissueMutation.ts
+++ b/src/hooks/api/reissue/useReissueMutation.ts
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from 'react';
 import { useMutation } from 'react-query';
 
 import { post } from '~/libs/api/client';
@@ -6,12 +7,25 @@ interface ReissueMutationRequest {
   refreshToken: string;
 }
 
-export default function useReissueMutation() {
-  return useMutation((data: ReissueMutationRequest) =>
-    post<AuthTokenResponseInterface>('/v1/reissue', undefined, {
-      headers: {
-        'REFRESH-TOKEN': data.refreshToken,
+interface UseReissueMutationProps {
+  userLogin: ({ accessToken, refreshToken }: { accessToken: string; refreshToken: string }) => void;
+  setIsLoaded: Dispatch<SetStateAction<boolean>>;
+}
+
+export default function useReissueMutation({ userLogin, setIsLoaded }: UseReissueMutationProps) {
+  return useMutation(
+    (data: ReissueMutationRequest) =>
+      post<AuthTokenResponseInterface>('/v1/reissue', undefined, {
+        headers: {
+          'REFRESH-TOKEN': data.refreshToken,
+        },
+      }),
+    {
+      onSuccess: data => {
+        const { accessToken, refreshToken } = data.data;
+        userLogin({ accessToken, refreshToken });
+        setIsLoaded(true);
       },
-    })
+    }
   );
 }

--- a/src/hooks/common/useDidUpdate/useDidUpdate.ts
+++ b/src/hooks/common/useDidUpdate/useDidUpdate.ts
@@ -9,5 +9,6 @@ export default function useDidUpdate(callback: VoidFunction, dependencyList: Dep
       return;
     }
     callback();
-  }, [callback, dependencyList]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...dependencyList]);
 }

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -21,18 +21,6 @@ export function replaceAccessTokenForRequestInstance(token: string) {
   instance.interceptors.request.use(interceptorRequestFulfilled);
 }
 
-// TODO: 로그인 로직 보수 후 삭제
-// 로그인 로직 보수 전, 브라우저 쿠키를 읽는
-function interceptorRequestFulfilled(config: AxiosRequestConfig) {
-  return {
-    ...config,
-    headers: {
-      accessToken: localStorage.getItem('accessToken'),
-    },
-  };
-}
-instance.interceptors.request.use(interceptorRequestFulfilled);
-
 // Response interceptor
 function interceptorResponseFulfilled(res: AxiosResponse) {
   if (200 <= res.status && res.status < 300) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,9 +16,9 @@ export default function App({ Component, pageProps }: AppProps) {
     <RecoilRoot>
       <ThemeProvider theme={CustomTheme}>
         <QueryClientProvider client={queryClient}>
+          <GlobalStyle />
           <UserProvider>
             <Layout>
-              <GlobalStyle />
               <Component {...pageProps} />
               <ToastSection />
             </Layout>

--- a/src/store/User/UserProvider.tsx
+++ b/src/store/User/UserProvider.tsx
@@ -10,12 +10,16 @@ import { useUser } from './';
 
 export function UserProvider({ children }: PropsWithChildren<unknown>) {
   const { isLoaded, setIsLoaded, userLogin, isLoggedIn } = useUser();
-  const { mutate: reissueMutate, error: reissueMutationError } = useReissueMutation({
-    userLogin,
-    setIsLoaded,
-  });
-  const { get: cookieGet } = useCookie();
 
+  const { mutate: reissueMutate, error: reissueMutationError } = useReissueMutation({
+    onSuccess: data => {
+      const { accessToken, refreshToken } = data.data;
+      userLogin({ accessToken, refreshToken });
+      setIsLoaded(true);
+    },
+  });
+
+  const { get: cookieGet } = useCookie();
   const { isRouterGuardPassed } = useRouterGuard({ isLoaded, isLoggedIn });
 
   // 컴포넌트 마운트 시

--- a/src/store/User/UserProvider.tsx
+++ b/src/store/User/UserProvider.tsx
@@ -3,45 +3,40 @@ import { PropsWithChildren, useEffect } from 'react';
 import { COOKIE_REFRESH } from '~/constants/common';
 import useReissueMutation from '~/hooks/api/reissue/useReissueMutation';
 import useCookie from '~/hooks/common/useCookie';
+import useDidMount from '~/hooks/common/useDidMount';
+import useRouterGuard from '~/hooks/common/useRouterGuard';
 
 import { useUser } from './';
 
 export function UserProvider({ children }: PropsWithChildren<unknown>) {
-  const { isLoaded, setIsLoaded, userLogin } = useUser();
-  const {
-    mutate: reissueMutate,
-    data: reissueMutationData,
-    error: reissueMutationError,
-  } = useReissueMutation();
+  const { isLoaded, setIsLoaded, userLogin, isLoggedIn } = useUser();
+  const { mutate: reissueMutate, error: reissueMutationError } = useReissueMutation({
+    userLogin,
+    setIsLoaded,
+  });
   const { get: cookieGet } = useCookie();
 
+  const { isRouterGuardPassed } = useRouterGuard({ isLoaded, isLoggedIn });
+
   // 컴포넌트 마운트 시
-  useEffect(() => {
-    if (!isLoaded) {
-      const storedRefreshToken = cookieGet(COOKIE_REFRESH);
+  useDidMount(() => {
+    if (isLoaded) return;
 
-      if (storedRefreshToken) {
-        reissueMutate({
-          refreshToken: storedRefreshToken,
-        });
-      } else {
-        setIsLoaded(true);
-      }
-    }
-  }, [cookieGet, isLoaded, reissueMutate, setIsLoaded]);
+    const storedRefreshToken = cookieGet(COOKIE_REFRESH);
 
-  useEffect(() => {
-    if (reissueMutationData && reissueMutationData.data) {
-      const { accessToken, refreshToken } = reissueMutationData.data;
-      userLogin({ accessToken, refreshToken });
+    if (storedRefreshToken) {
+      reissueMutate({
+        refreshToken: storedRefreshToken,
+      });
+    } else {
       setIsLoaded(true);
     }
-  }, [reissueMutationData, setIsLoaded, userLogin]);
+  });
 
   useEffect(() => {
     // TODO: 에러 발생 핸들링
   }, [reissueMutationError]);
 
   // TODO: 로딩 관련 처리하기
-  return <>{isLoaded ? children : <>로그인 대기 중...</>}</>;
+  return <>{isRouterGuardPassed ? children : <>로그인 대기 중...</>}</>;
 }


### PR DESCRIPTION
## ⛳️작업 내용

- 비로그인시 non public route에 접근하면, 로그인 화면으로 가도록 대윤님께서 작업해주신 `useRouterGuard`를 수정, 사용했슴니다
  - useRouterGuard는 UserProvider에서 사용하였는데 전체적인 흐름은 아래에서 설명드릴게오

- `useDidUpdate`의 의존성 배열을 수정하였어요.
  -  기존에는 array를 통채로 넣어줬으나, 의존성 배열에서 array는 레퍼런스로 비교한다하여 예상한대로 동작하지 않다고 판단하여 스프레드 연산자를 사용하는 방법으로 수정하였습니다

- reissue 전에 사용하던 `api client`의 로컬스토리지를 읽는 인터셉터를 지웠어요

- `useReissueMutation`에서 성공 시에 필요한 콜백을 주입받아 `onSuccess` 시에 실행하도록 수정했어요
 

## 📸스크린샷

https://user-images.githubusercontent.com/26461307/168230041-3162a7dc-f177-4927-9c6e-6daae0277329.mov

> 제 테스트용 계정이 비밀번호가 4자리라 .... form에서 걸려서... 슬랙에 올려진 은정님 게정 사용했읍니다 ...

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎 UserProvider 로직

1. `useUser`의 `isLoaded`는 다음의 경우에 true가 됩니다

- 쿠키에 refreshToken이 없는 경우
- refreshToken이 있으며, reissue에 성공한 경우

2. `useRouterGuard`의 `isRouterGuardPassed`는 다음의 경우에 true가 됩니다.

> isLoaded가 false일 시 연산하지 않습니다.

- useUser의 `isLoggedIn`이 true인 경우 (전역 상태에 accessToken, refreshToken이 존재)
- 현재 url이 `public path`인 경우 (isLoggedIn이 false이며 public path가 아닌 경우 login으로 push)

3. UserProvider는 `isRouterGuardPassed`일 시에만 `children`을 반환합니다


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
