### PR TITLE
영감 추가 - 이미지 추가 기능 완성 및 업로드 에러 해결

### DIFF
--- a/src/components/add/ImgUploader.tsx
+++ b/src/components/add/ImgUploader.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from 'react';
+import { css } from '@emotion/react';
+
+interface ImgUploaderProps {
+  imgInputUploader: ({ target }: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const ImgUploader = forwardRef(
+  ({ imgInputUploader }: ImgUploaderProps, imgInputRef: React.ForwardedRef<HTMLInputElement>) => {
+    return (
+      <input
+        ref={imgInputRef}
+        css={imgInputCss}
+        onChange={imgInputUploader}
+        type="file"
+        accept="image/*, .jpg,.png,.bmp,.gif,.tif,.webp,.heic,.jpeg,.tiff,.heif"
+      />
+    );
+  }
+);
+
+ImgUploader.displayName = 'ImgUploader';
+
+const imgInputCss = css`
+  display: none;
+`;

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -3,8 +3,9 @@ import { css, Theme, useTheme } from '@emotion/react';
 import { CancelIcon } from './icons';
 
 interface ImageContentProps {
-  src?: string;
+  clickXbtn: VoidFunction;
   alt: string;
+  src: string | null;
   width?: string;
   height?: string;
 }
@@ -14,12 +15,13 @@ export default function ImageContent({
   alt = 'blank',
   width = '100%',
   height,
+  clickXbtn,
 }: ImageContentProps) {
   const theme = useTheme();
 
   return (
     <div css={imgBoxCss({ width, height, theme })}>
-      <button css={closeIconCss}>
+      <button onClick={clickXbtn} css={closeIconCss}>
         <CancelIcon isUsingFill color={theme.color.gray05} />
       </button>
       {src && <img src={src} css={imgBoxCss({ width, height, theme })} alt={alt} />}

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useId } from 'react';
+import { useId } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 
 import { labelCss } from '~/components/common/styles';
-import useInput from '~/hooks/common/useInput';
 
 import { EditIcon } from '../icons';
 import { TextField } from './TextField';
@@ -40,12 +39,16 @@ export interface MemoTextProps {
   /**
    * onChange 핸들링 함수입니다. 주입해주어야 합니다.
    */
-  onChange?: (value: string) => void;
+  onChange: (
+    event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
+  ) => void;
 
   /**
    * 수정(저장) 아이콘을 누르면 실행되는 함수입니다. 주입해주어야 합니다.
    */
   onSaveClick?: () => void;
+  value: string;
+  debouncedValue: string;
 }
 
 export function MemoText({
@@ -56,22 +59,22 @@ export function MemoText({
   wordLimit,
   onChange: onValueChange,
   onSaveClick,
+  value,
+  debouncedValue,
 }: MemoTextProps) {
   const id = useId();
   const theme = useTheme();
-  const { value, onChange, debouncedValue } = useInput({ useDebounce: true });
 
-  useEffect(() => {
-    if (onValueChange) {
-      onValueChange(debouncedValue);
-    }
-  }, [debouncedValue, onValueChange]);
+  // useEffect(() => {
+  //   if (!onValueChange) return;
+  //   onValueChange(debouncedValue);
+  // }, [debouncedValue, onValueChange]);
 
   return (
     <TextField
       as={'textarea'}
       value={value}
-      onChange={onChange}
+      onChange={onValueChange}
       placeholder={placeholder ?? '어떤 것이 영감을 주었나요?'}
       maxLength={wordLimit}
       fixedHeight={100}

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -47,7 +47,15 @@ export interface MemoTextProps {
    * 수정(저장) 아이콘을 누르면 실행되는 함수입니다. 주입해주어야 합니다.
    */
   onSaveClick?: () => void;
+
+  /**
+   * 메모 value 입니다.
+   */
   value: string;
+
+  /**
+   * 메모 debouncedValue 입니다.
+   */
   debouncedValue: string;
 }
 
@@ -64,11 +72,6 @@ export function MemoText({
 }: MemoTextProps) {
   const id = useId();
   const theme = useTheme();
-
-  // useEffect(() => {
-  //   if (!onValueChange) return;
-  //   onValueChange(debouncedValue);
-  // }, [debouncedValue, onValueChange]);
 
   return (
     <TextField

--- a/src/components/home/AppendTooltip.tsx
+++ b/src/components/home/AppendTooltip.tsx
@@ -9,7 +9,7 @@ import useInternalRouter, { RouterPathType } from '~/hooks/common/useInternalRou
 import { useUploadedImg } from '~/store/UploadedImage';
 
 export default function AppendTooltip() {
-  const { uploadImg, uploadedImg } = useUploadedImg();
+  const { uploadImg } = useUploadedImg();
   const { push } = useInternalRouter();
   const imgInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/home/AppendTooltip.tsx
+++ b/src/components/home/AppendTooltip.tsx
@@ -30,10 +30,11 @@ export default function AppendTooltip() {
 
     if (files) {
       getBase64(files[0], result => {
-        if (typeof result === 'string') uploadImg(result);
+        if (typeof result === 'string') {
+          uploadImg(result);
+          push('/add/image');
+        }
       });
-
-      uploadedImg && push('/add/image');
     }
   };
 

--- a/src/components/home/AppendTooltip.tsx
+++ b/src/components/home/AppendTooltip.tsx
@@ -1,60 +1,29 @@
-import { ReactNode, useRef } from 'react';
+import { ReactNode } from 'react';
 import { css, Theme } from '@emotion/react';
 import { motion, Variants } from 'framer-motion';
 
 import { EditIcon, ImageIcon, LinkIcon } from '~/components/common/icons';
 import InternalLink from '~/components/common/InternalLink';
 import { defaultEasing } from '~/constants/motions';
-import useInternalRouter, { RouterPathType } from '~/hooks/common/useInternalRouter';
-import { useUploadedImg } from '~/store/UploadedImage';
+import useImgUpload from '~/hooks/common/useImgUpload';
+import { RouterPathType } from '~/hooks/common/useInternalRouter';
+
+import { ImgUploader } from '../add/ImgUploader';
 
 export default function AppendTooltip() {
-  const { uploadImg } = useUploadedImg();
-  const { push } = useInternalRouter();
-  const imgInputRef = useRef<HTMLInputElement>(null);
-
-  const openInputFile = () => {
-    if (!imgInputRef.current) return;
-    imgInputRef.current.click();
-  };
-
-  const getBase64 = (file: Blob, onload: (file: unknown) => void) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = () => onload(reader.result);
-    reader.onerror = error => console.log(error);
-  };
-
-  const imgInputUploader = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = target;
-
-    if (files) {
-      getBase64(files[0], result => {
-        if (typeof result === 'string') {
-          uploadImg(result);
-          push('/add/image');
-        }
-      });
-    }
-  };
+  const { imgInputRef, openFileInput, imgInputUploader } = useImgUpload({ isUploadPage: false });
 
   return (
     <motion.div css={wrapperCss} variants={tooltipVariants}>
       <AnchorElement href="/add/text" icon={<EditIcon />} title="글" />
       <AnchorElement
         href="/add/image"
-        onClick={openInputFile}
+        onClick={openFileInput}
         icon={<ImageIcon />}
         title="이미지"
       />
       <AnchorElement href="/add/link" icon={<LinkIcon />} title="링크" />
-      <input
-        ref={imgInputRef}
-        css={imgInputCss}
-        onChange={imgInputUploader}
-        type="file"
-        accept="image/*, .jpg,.png,.bmp,.gif,.tif,.webp,.heic,.jpeg,.tiff,.heif"
-      />
+      <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
     </motion.div>
   );
 }
@@ -136,7 +105,3 @@ const tooltipVariants: Variants = {
     willChange: 'opacity, transform',
   },
 };
-
-const imgInputCss = css`
-  display: none;
-`;

--- a/src/hooks/common/useImgUpload.ts
+++ b/src/hooks/common/useImgUpload.ts
@@ -4,6 +4,10 @@ import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useUploadedImg } from '~/store/UploadedImage';
 
 export interface UseImgUploadType {
+  /**
+   * 이미지 영감 추가 페이지가 아닐 때 이미지 선택 후 해당 페이지로 이동합니다.
+   * @default true
+   */
   isUploadPage?: boolean;
 }
 
@@ -17,15 +21,16 @@ export default function useImgUpload({ isUploadPage = true }: UseImgUploadType) 
     imgInputRef.current.click();
   };
 
+  // Blob 타입의 이미지 파일을 base64 형태로 변환합니다.
+  const getBase64 = (file: Blob, onload: (file: unknown) => void) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => onload(reader.result);
+    reader.onerror = error => console.log(error);
+  };
+
   const imgInputUploader = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = target;
-
-    const getBase64 = (file: Blob, onload: (file: unknown) => void) => {
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = () => onload(reader.result);
-      reader.onerror = error => console.log(error);
-    };
 
     if (files) {
       getBase64(files[0], result => {
@@ -38,8 +43,31 @@ export default function useImgUpload({ isUploadPage = true }: UseImgUploadType) 
   };
 
   return {
+    /**
+     * 이미지 input와 연결할 ref입니다.
+     *
+     * ```js
+     * <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
+     * ```
+     */
     imgInputRef,
+
+    /**
+     * 이미지 파일 인풋 창을 엽니다.
+     *
+     * ```js
+     * <button onClick={openFileInput} />
+     * ```
+     */
     openFileInput,
+
+    /**
+     * 이미지 input와 연결해서 이미지 파일을 base64로 포맷팅하고 상태로 저장하는 업로더입니다.
+     *
+     * ```js
+     * <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
+     * ```
+     */
     imgInputUploader,
   };
 }

--- a/src/hooks/common/useImgUpload.ts
+++ b/src/hooks/common/useImgUpload.ts
@@ -1,0 +1,45 @@
+import { useRef } from 'react';
+
+import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { useUploadedImg } from '~/store/UploadedImage';
+
+export interface UseImgUploadType {
+  isUploadPage?: boolean;
+}
+
+export default function useImgUpload({ isUploadPage = true }: UseImgUploadType) {
+  const imgInputRef = useRef<HTMLInputElement>(null);
+  const { uploadImg } = useUploadedImg();
+  const { push } = useInternalRouter();
+
+  const openFileInput = () => {
+    if (!imgInputRef.current) return;
+    imgInputRef.current.click();
+  };
+
+  const imgInputUploader = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = target;
+
+    const getBase64 = (file: Blob, onload: (file: unknown) => void) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => onload(reader.result);
+      reader.onerror = error => console.log(error);
+    };
+
+    if (files) {
+      getBase64(files[0], result => {
+        if (typeof result === 'string') {
+          uploadImg(result);
+          !isUploadPage && push('/add/image');
+        }
+      });
+    }
+  };
+
+  return {
+    imgInputRef,
+    openFileInput,
+    imgInputUploader,
+  };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,17 +13,6 @@ import GlobalStyle from '~/styles/GlobalStyle';
 import CustomTheme from '~/styles/Theme';
 
 export default function App({ Component, pageProps }: AppProps) {
-  useEffect(() => {
-    localStorage.setItem(
-      'accessToken',
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2Iiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sIm1lbWJlcl9pZCI6NiwiaWF0IjoxNjUyNDM1MTA5LCJleHAiOjE2NTI0Mzg3MDl9.vbXOTE4ERo2dSDnSFdM2C3DkV_ttu81T0IgiQWOPv34'
-    );
-    localStorage.setItem(
-      'refreshToken',
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2Iiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sIm1lbWJlcl9pZCI6NiwiZXhwIjoxNjUzNjQ0NzA5fQ.X8jUQoyrAEVRBqdOW08En_8YqrsG0vmC7jghXXc7g_k'
-    );
-  }, []);
-
   return (
     <RecoilRoot>
       <ThemeProvider theme={CustomTheme}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,17 @@ import GlobalStyle from '~/styles/GlobalStyle';
 import CustomTheme from '~/styles/Theme';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    localStorage.setItem(
+      'accessToken',
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2Iiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sIm1lbWJlcl9pZCI6NiwiaWF0IjoxNjUyNDM1MTA5LCJleHAiOjE2NTI0Mzg3MDl9.vbXOTE4ERo2dSDnSFdM2C3DkV_ttu81T0IgiQWOPv34'
+    );
+    localStorage.setItem(
+      'refreshToken',
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2Iiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sIm1lbWJlcl9pZCI6NiwiZXhwIjoxNjUzNjQ0NzA5fQ.X8jUQoyrAEVRBqdOW08En_8YqrsG0vmC7jghXXc7g_k'
+    );
+  }, []);
+
   return (
     <RecoilRoot>
       <ThemeProvider theme={CustomTheme}>

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { css } from '@emotion/react';
 
+import { ImgUploader } from '~/components/add/ImgUploader';
 import { CTAButton } from '~/components/common/Button';
 import TagContent from '~/components/common/Content/TagContent';
 import ImageContent from '~/components/common/ImageContent';
@@ -9,10 +10,12 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation, {
   InspirationMutationRequest,
 } from '~/hooks/api/inspiration/useInspirationMutation';
+import useImgUpload from '~/hooks/common/useImgUpload';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useUploadedImg } from '~/store/UploadedImage';
 
 export default function AddImage() {
+  const { imgInputRef, openFileInput, imgInputUploader } = useImgUpload({});
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
   const { createInspiration } = useInspirationMutation();
@@ -40,9 +43,10 @@ export default function AddImage() {
       <NavigationBar title="이미지 추가" />
 
       <form onSubmit={submitImg} css={formCss}>
+        <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
         <section css={addImageTopCss}>
           <div css={contentWrapperCss}>
-            {uploadedImg && <ImageContent src={uploadedImg} alt="uploadedImg" />}
+            {<ImageContent clickXbtn={openFileInput} src={uploadedImg} alt="uploadedImg" />}
           </div>
           <div css={contentWrapperCss}>
             <TagContent onEdit={() => {}} tags={tags} />

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
@@ -8,11 +9,17 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation, {
   InspirationMutationRequest,
 } from '~/hooks/api/inspiration/useInspirationMutation';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useUploadedImg } from '~/store/UploadedImage';
 
 export default function AddImage() {
+  const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
   const { createInspiration } = useInspirationMutation();
+
+  useEffect(() => {
+    if (!uploadedImg) push('/');
+  }, [uploadedImg, push]);
 
   const tags = [{ id: 1, content: '1111' }];
 
@@ -31,7 +38,8 @@ export default function AddImage() {
   return (
     <article css={addImageCss}>
       <NavigationBar title="이미지 추가" />
-      <form onSubmit={submitImg}>
+
+      <form onSubmit={submitImg} css={formCss}>
         <section css={addImageTopCss}>
           <div css={contentWrapperCss}>
             {uploadedImg && <ImageContent src={uploadedImg} alt="uploadedImg" />}
@@ -43,6 +51,7 @@ export default function AddImage() {
             <MemoText writable />
           </div>
         </section>
+
         <section css={addImageBottomCss}>
           <CTAButton type="submit">Tang!</CTAButton>
         </section>
@@ -54,8 +63,14 @@ export default function AddImage() {
 const addImageCss = css`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: calc(var(--vh, 1vh) * 100);
   overflow: hidden;
+`;
+
+const formCss = css`
+  height: calc(var(--vh, 1vh) * 100 - 44px);
+  display: flex;
+  flex-direction: column;
 `;
 
 const addImageTopCss = css`

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -11,10 +11,17 @@ import useInspirationMutation, {
   InspirationMutationRequest,
 } from '~/hooks/api/inspiration/useInspirationMutation';
 import useImgUpload from '~/hooks/common/useImgUpload';
+import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useUploadedImg } from '~/store/UploadedImage';
 
 export default function AddImage() {
+  const {
+    onChange: onMemoChange,
+    debouncedValue: memoDebouncedValue,
+    value: memoValue,
+  } = useInput({ useDebounce: true });
+
   const { imgInputRef, openFileInput, imgInputUploader } = useImgUpload({});
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
@@ -31,7 +38,7 @@ export default function AddImage() {
     if (!uploadedImg) return;
     const imgData: InspirationMutationRequest = {
       file: uploadedImg,
-      memo: 'memo~',
+      memo: memoValue,
       tagIds: [1],
       type: 'IMAGE',
     };
@@ -52,7 +59,12 @@ export default function AddImage() {
             <TagContent onEdit={() => {}} tags={tags} />
           </div>
           <div css={contentWrapperCss}>
-            <MemoText writable />
+            <MemoText
+              writable
+              onChange={onMemoChange}
+              debouncedValue={memoDebouncedValue}
+              value={memoValue}
+            />
           </div>
         </section>
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -6,6 +6,7 @@ import { CTAButton } from '~/components/common/Button';
 import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
 import { MemoText } from '~/components/common/TextField';
+import useInput from '~/hooks/common/useInput';
 
 export interface OpenGraph {
   description: string;
@@ -16,6 +17,11 @@ export interface OpenGraph {
 }
 
 export default function AddLink() {
+  const {
+    onChange: onMemoChange,
+    debouncedValue: memoDebouncedValue,
+    value: memoValue,
+  } = useInput({ useDebounce: true });
   const [openGraph, setOpenGraph] = useState<OpenGraph | null>(null);
 
   return (
@@ -29,7 +35,12 @@ export default function AddLink() {
           <TagContent onEdit={() => {}} tags={[]} />
         </div>
         <div css={contentWrapperCss}>
-          <MemoText writable />
+          <MemoText
+            onChange={onMemoChange}
+            debouncedValue={memoDebouncedValue}
+            value={memoValue}
+            writable
+          />
         </div>
       </section>
 

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -9,6 +9,11 @@ import useInput from '~/hooks/common/useInput';
 
 export default function AddText() {
   const inspiringText = useInput({ useDebounce: true });
+  const {
+    onChange: onMemoChange,
+    debouncedValue: memoDebouncedValue,
+    value: memoValue,
+  } = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
 
   return (
@@ -27,7 +32,12 @@ export default function AddText() {
           <TagContent onEdit={() => {}} tags={[]} />
         </div>
         <div css={contentWrapperCss}>
-          <MemoText writable />
+          <MemoText
+            writable
+            onChange={onMemoChange}
+            debouncedValue={memoDebouncedValue}
+            value={memoValue}
+          />
         </div>
       </section>
       <section css={addTextBottomCss}>

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -14,11 +14,18 @@ import NavigationBar from '~/components/common/NavigationBar';
 import TextField, { MemoText } from '~/components/common/TextField';
 import { SearchBar } from '~/components/common/TextField/SearchBar';
 import LinkThumbnail from '~/components/LinkThumbnail';
+import useInput from '~/hooks/common/useInput';
 import { useUserAgent } from '~/hooks/common/useUserAgent';
 import { useToast } from '~/store/Toast';
 import theme from '~/styles/Theme';
 
 export default function Test() {
+  const {
+    onChange: onMemoChange,
+    debouncedValue: memoDebouncedValue,
+    value: memoValue,
+  } = useInput({ useDebounce: true });
+
   const { fireToast } = useToast();
   const { isMobile, isIos, isAndroid, isDesktop } = useUserAgent();
   const [isSSR, setIsSSR] = useState(true);
@@ -170,7 +177,13 @@ export default function Test() {
         체크 리스트
       </CheckList>
       <SearchBar readOnly value={'asdasdasd'} />
-      <MemoText editable wordLimit={150} />
+      <MemoText
+        writable
+        onChange={onMemoChange}
+        debouncedValue={memoDebouncedValue}
+        value={memoValue}
+        wordLimit={150}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### [fix: 이미지에 따라 업로드 되지 않는 에러 해결](https://github.com/depromeet/11th_7team_web/commit/efa8f8deed2d8cdede47b9edfb90ccccca68731d)

issue #187 해결했습니다.

### [feat: 업로드 이미지 삭제 시 자동 인풋 오픈 및 useImgUpload 훅 생성](https://github.com/depromeet/11th_7team_web/commit/893fbbb3fd26fdf52eaf3b8d053e48c1adf771a5)

- 이미지 콘텐츠를 업로드 한 후 x 버튼을 클릭했을 때 자동으로 이미지 업로드 인풋이 다시 활성화되는 기능을 추가했습니다. (디자이너 분들 답변)
- 해당 img uploader와 useImgUpload를 공통 컴포넌트와 공통 훅으로 재사용할 수 있도록 했습니다. (이미지 업로더는 add 폴더 안에 넣긴 했어요..! )

### [feat: 이미지 업로드 api 메모 연결](https://github.com/depromeet/11th_7team_web/commit/19857068934788c6c2ac3a2cb5406d86a6adee45)

이미지 업로드 페이지에서 메모를 함께 fetching할 수 있도록 수정했습니다.
이제 대윤님이 태그만 이어붙여주시면 될 듯! 부탁드립니다..!



<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
