### PR TITLE
테그 - 추가 모달 버그 및 readOnly추가

### DIFF
--- a/src/components/TagForm/index.tsx
+++ b/src/components/TagForm/index.tsx
@@ -9,6 +9,15 @@ import useInput from '~/hooks/common/useInput';
 import AppliedTags from './AppliedTags';
 import RegisteredTagList from './RegisteredTagList';
 
+export interface TagFormProps {
+  applyedTags: TagType[];
+  registeredTags: TagType[];
+  onSave: (tag: TagType) => void;
+  onRemove: (id: number) => void;
+  onSearch?: (keyword: string) => void;
+  readOnly?: boolean;
+}
+
 // NOTE: Props들을 컴포넌트내에서 관리할 수도 있지 않을까
 export default function TagForm({
   applyedTags = [],
@@ -16,13 +25,8 @@ export default function TagForm({
   onSave,
   onRemove,
   onSearch,
-}: {
-  applyedTags: TagType[];
-  registeredTags: TagType[];
-  onSave: (tag: TagType) => void;
-  onRemove: (id: number) => void;
-  onSearch?: (keyword: string) => void;
-}) {
+  readOnly = false,
+}: TagFormProps) {
   const { value, setValue, onChange } = useInput({ useDebounce: false });
   const [keyword, setKeyword] = useState('');
   const lastKeyword = useRef<string | null>(null);
@@ -48,15 +52,15 @@ export default function TagForm({
     if (keyword === lastKeyword.current) return;
     if (!isLoading) onSearch && onSearch(keyword);
     if (!isLoading && keyword) {
-      if (!tags.length) {
+      if (!tags.length && !readOnly) {
         saveCreatedTag(keyword);
-      } else {
+      } else if (tags.length) {
         onSave(tags[0]);
       }
       lastKeyword.current = keyword;
       setValue('');
     }
-  }, [isLoading, keyword, onSave, onSearch, saveCreatedTag, setValue, tags]);
+  }, [isLoading, keyword, onSave, onSearch, saveCreatedTag, setValue, tags, readOnly]);
 
   const onFormReturn = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/common/Content/TagContent.tsx
+++ b/src/components/common/Content/TagContent.tsx
@@ -29,7 +29,7 @@ export default function TagContent({ tags, label = '태그', onClickTag }: TagCo
               }}
             />
           ))}
-          <Link href="/?modal=addTag" as="/add/tag" scroll={false}>
+          <Link href="?modal=addTag" as="/add/tag" scroll={false}>
             <a>
               <IconButton iconName="PlusIcon" />
             </a>

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
 import { ImgUploader } from '~/components/add/ImgUploader';
@@ -15,6 +16,8 @@ import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useUploadedImg } from '~/store/UploadedImage';
+
+const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddImage() {
   const {
@@ -46,33 +49,36 @@ export default function AddImage() {
   };
 
   return (
-    <article css={addImageCss}>
-      <NavigationBar title="이미지 추가" />
+    <>
+      <article css={addImageCss}>
+        <NavigationBar title="이미지 추가" />
 
-      <form onSubmit={submitImg} css={formCss}>
-        <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
-        <section css={addImageTopCss}>
-          <div css={contentWrapperCss}>
-            {<ImageContent clickXbtn={openFileInput} src={uploadedImg} alt="uploadedImg" />}
-          </div>
-          <div css={contentWrapperCss}>
-            <TagContent tags={tags} />
-          </div>
-          <div css={contentWrapperCss}>
-            <MemoText
-              writable
-              onChange={onMemoChange}
-              debouncedValue={memoDebouncedValue}
-              value={memoValue}
-            />
-          </div>
-        </section>
+        <form onSubmit={submitImg} css={formCss}>
+          <ImgUploader imgInputUploader={imgInputUploader} ref={imgInputRef} />
+          <section css={addImageTopCss}>
+            <div css={contentWrapperCss}>
+              {<ImageContent clickXbtn={openFileInput} src={uploadedImg} alt="uploadedImg" />}
+            </div>
+            <div css={contentWrapperCss}>
+              <TagContent tags={tags} />
+            </div>
+            <div css={contentWrapperCss}>
+              <MemoText
+                writable
+                onChange={onMemoChange}
+                debouncedValue={memoDebouncedValue}
+                value={memoValue}
+              />
+            </div>
+          </section>
 
-        <section css={addImageBottomCss}>
-          <CTAButton type="submit">Tang!</CTAButton>
-        </section>
-      </form>
-    </article>
+          <section css={addImageBottomCss}>
+            <CTAButton type="submit">Tang!</CTAButton>
+          </section>
+        </form>
+      </article>
+      <AddTagFormRouteAsModal />
+    </>
   );
 }
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
 import LinkInput from '~/components/add/LinkInput';
@@ -14,6 +15,7 @@ import { useAppliedTags } from '~/store/AppliedTags';
 
 import { formCss } from './image';
 
+const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 export interface OpenGraph {
   description: string;
   siteName: string;
@@ -45,34 +47,37 @@ export default function AddLink() {
   };
 
   return (
-    <article css={addLinkCss}>
-      <NavigationBar title="링크 추가" />
+    <>
+      <article css={addLinkCss}>
+        <NavigationBar title="링크 추가" />
 
-      <form onSubmit={submitLink} css={formCss}>
-        <section css={addLinkTopCss}>
-          <div css={contentWrapperCss}>
-            <LinkInput openGraph={openGraph} setOpenGraph={setOpenGraph} />
-          </div>
-          <div css={contentWrapperCss}>
-            <TagContent tags={tags} />
-          </div>
-          <div css={contentWrapperCss}>
-            <MemoText
-              onChange={onMemoChange}
-              debouncedValue={memoDebouncedValue}
-              value={memoValue}
-              writable
-            />
-          </div>
-        </section>
+        <form onSubmit={submitLink} css={formCss}>
+          <section css={addLinkTopCss}>
+            <div css={contentWrapperCss}>
+              <LinkInput openGraph={openGraph} setOpenGraph={setOpenGraph} />
+            </div>
+            <div css={contentWrapperCss}>
+              <TagContent tags={tags} />
+            </div>
+            <div css={contentWrapperCss}>
+              <MemoText
+                onChange={onMemoChange}
+                debouncedValue={memoDebouncedValue}
+                value={memoValue}
+                writable
+              />
+            </div>
+          </section>
 
-        <section css={addLinkBottomCss}>
-          <CTAButton disabled={!Boolean(openGraph)} type="submit">
-            Tang!
-          </CTAButton>
-        </section>
-      </form>
-    </article>
+          <section css={addLinkBottomCss}>
+            <CTAButton disabled={!Boolean(openGraph)} type="submit">
+              Tang!
+            </CTAButton>
+          </section>
+        </form>
+      </article>
+      <AddTagFormRouteAsModal />
+    </>
   );
 }
 

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -1,3 +1,4 @@
+import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
@@ -12,6 +13,8 @@ import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
 
 import { formCss } from './image';
+
+const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddText() {
   const inspiringText = useInput({ useDebounce: true });
@@ -33,39 +36,42 @@ export default function AddText() {
   };
 
   return (
-    <article css={addTextCss}>
-      <NavigationBar title="글 추가" />
+    <>
+      <article css={addTextCss}>
+        <NavigationBar title="글 추가" />
 
-      <form onSubmit={submitText} css={formCss}>
-        <section css={addTextTopCss}>
-          <div css={contentWrapperCss}>
-            <Input
-              as="textarea"
-              placeholder="영감을 작성해 보세요."
-              value={inspiringText.value}
-              onChange={inspiringText.onChange}
-            />
-          </div>
-          <div css={contentWrapperCss}>
-            <TagContent tags={tags} />
-          </div>
-          <div css={contentWrapperCss}>
-            <MemoText
-              writable
-              onChange={memoText.onChange}
-              debouncedValue={memoText.debouncedValue}
-              value={memoText.value}
-            />
-          </div>
-        </section>
+        <form onSubmit={submitText} css={formCss}>
+          <section css={addTextTopCss}>
+            <div css={contentWrapperCss}>
+              <Input
+                as="textarea"
+                placeholder="영감을 작성해 보세요."
+                value={inspiringText.value}
+                onChange={inspiringText.onChange}
+              />
+            </div>
+            <div css={contentWrapperCss}>
+              <TagContent tags={tags} />
+            </div>
+            <div css={contentWrapperCss}>
+              <MemoText
+                writable
+                onChange={memoText.onChange}
+                debouncedValue={memoText.debouncedValue}
+                value={memoText.value}
+              />
+            </div>
+          </section>
 
-        <section css={addTextBottomCss}>
-          <CTAButton type="submit" disabled={isEmptyText}>
-            Tang!
-          </CTAButton>
-        </section>
-      </form>
-    </article>
+          <section css={addTextBottomCss}>
+            <CTAButton type="submit" disabled={isEmptyText}>
+              Tang!
+            </CTAButton>
+          </section>
+        </form>
+      </article>
+      <AddTagFormRouteAsModal />
+    </>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,6 @@ import { useFilteredTags } from '~/store/FilteredTags';
 
 //TODO: 이후 내부만 살짝 바꾸어서 modal type에 따라 사용할 수 있습니다.
 const TagFormRouteAsModal = dynamic(() => import('~/components/home/TagFormRouteAsModal'));
-const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function Root() {
   const { filteredTags, removeTag } = useFilteredTags({});
@@ -74,7 +73,6 @@ export default function Root() {
       </motion.article>
       <AppendButton />
       <TagFormRouteAsModal />
-      <AddTagFormRouteAsModal />
     </>
   );
 }

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { motion } from 'framer-motion';
 
 import LoadingHandler from '~/components/common/LoadingHandler';
@@ -10,7 +11,8 @@ import { useFilteredTags } from '~/store/FilteredTags';
 
 export default function TagPage() {
   const { filteredTags, addTag, removeTag } = useFilteredTags({});
-  const { tags, isLoading } = useGetTagListWithInfinite({});
+  const [keyword, setKeyword] = useState('');
+  const { tags, isLoading } = useGetTagListWithInfinite({ keyword });
 
   return (
     <article>
@@ -28,6 +30,10 @@ export default function TagPage() {
             registeredTags={tags}
             onSave={addTag}
             onRemove={removeTag}
+            onSearch={keyword => {
+              setKeyword(keyword);
+            }}
+            readOnly
           />
         </motion.div>
       </LoadingHandler>


### PR DESCRIPTION
## ⛳️작업 내용
- 테그 Link as를 정확하게 사용하기위한 업데이트를 진행했습니다.
- TagForm에 readOnly props를 추가하여 create하는 경우를 분기해서 사용할 수 있도록했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

https://user-images.githubusercontent.com/59507527/168290132-62d6e17b-5873-487e-b899-60436ad2920a.mov

https://user-images.githubusercontent.com/59507527/168290231-c2287282-1923-4a01-a479-c85b809bf830.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
### TagForm 검색 전용인 경우, like 필터 검색
```tsx
<TagForm
  applyedTags={filteredTags}
  registeredTags={tags}
  onSave={addTag}
  onRemove={removeTag}
  onSearch={keyword => {
    setKeyword(keyword);
  }}
  readOnly
/>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
