### PR TITLE
영감 인터페이스 중 TagResponses 대응

### DIFF
--- a/src/components/home/Thumbnail.tsx
+++ b/src/components/home/Thumbnail.tsx
@@ -9,7 +9,7 @@ import ThumbnailContent from './ThumbnailContent';
 
 export interface ContentThumbnailProps
   extends Pick<InspirationInterface, 'type' | 'content' | 'id'> {
-  tags: InspirationInterface['tagResponse'];
+  tags: InspirationInterface['tagResponses'];
   openGraph?: InspirationInterface['openGraphResponse'];
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,13 +55,13 @@ export default function Root() {
                 animate="animate"
                 exit="exit"
               >
-                {inspirations.map(({ id, type, content, tagResponse, openGraphResponse }) => (
+                {inspirations.map(({ id, type, content, tagResponses, openGraphResponse }) => (
                   <Thumbnail
                     key={id}
                     id={id}
                     type={type as InspirationType}
                     content={content}
-                    tags={tagResponse}
+                    tags={tagResponses}
                     openGraph={openGraphResponse}
                   />
                 ))}

--- a/src/remotes/inspiration.d.ts
+++ b/src/remotes/inspiration.d.ts
@@ -12,7 +12,7 @@ interface OpenGraphResonse {
 interface InspirationInterface {
   id: number;
   memberResponse: MemberResponseInterface;
-  tagResponse: TagInterface[];
+  tagResponses: TagInterface[];
   type: InspirationType;
   content: string;
   memo: string;


### PR DESCRIPTION
## ⛳️작업 내용

영감 리스트 조회 서버 스펙 중 `TagResponse`가 `TagResponses`로 변경된 것을 대응하였읍니다

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
