### PR TITLE
영감 추가 - 테그 추가 API 적용 및 Tag React.memo 적용

### DIFF
--- a/src/components/TagForm/AppliedTags.tsx
+++ b/src/components/TagForm/AppliedTags.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 
 import Tag from '~/components/common/Tag';
 
-export default function AppliedTags({
+function AppliedTags({
   applyedTags = [],
   onRemove,
 }: {
@@ -33,24 +33,23 @@ export default function AppliedTags({
     setPreviousTags([...applyedTags]);
   }, [applyedTags, previousTags]);
 
-  return useMemo(
-    () => (
-      <div ref={$container} css={applyedTagsCss}>
-        {applyedTags.map(tag => (
-          <Tag
-            key={tag.id}
-            content={tag.content}
-            deletable
-            onDelete={() => {
-              onRemove(tag.id);
-            }}
-          />
-        ))}
-      </div>
-    ),
-    [applyedTags, onRemove]
+  return (
+    <div ref={$container} css={applyedTagsCss}>
+      {applyedTags.map(tag => (
+        <Tag
+          key={tag.id}
+          content={tag.content}
+          deletable
+          onDelete={() => {
+            onRemove(tag.id);
+          }}
+        />
+      ))}
+    </div>
   );
 }
+
+export default React.memo(AppliedTags);
 
 const applyedTagsCss = css`
   display: flex;

--- a/src/components/TagForm/index.tsx
+++ b/src/components/TagForm/index.tsx
@@ -33,15 +33,11 @@ export default function TagForm({
   const { tags, isLoading } = useGetTagListWithInfinite({ keyword, isExactlySame: true });
   const { createTag } = useTagMutation();
 
-  //TODO: API 업데이트 이후 data가 내려오면 정상 동작 예정입니다.
-  //TODO: 아직 중복처리가 API 단에서 이루어지지 않아서 이렇게 작업을 올립니다.
   const saveCreatedTag = useCallback(
     (keyword: string) => {
       createTag(keyword, {
         onSuccess: data => {
-          // onSave(data.data);
-          const _data = data;
-          onSave({ id: 32131, content: '된다고 쳐' });
+          onSave(data);
         },
       });
     },

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,4 +1,5 @@
-import { css, Theme } from '@emotion/react';
+import React, { useRef } from 'react';
+import { css, Theme, useTheme } from '@emotion/react';
 
 import { selectRandomColor } from '~/utils/selectRandomColor';
 
@@ -9,19 +10,16 @@ export interface TagProps extends Pick<TagInterface, 'content'> {
   onDelete?: VoidFunction;
   onClick?: VoidFunction;
 }
+function Tag({ content, deletable = false, onDelete = () => {}, onClick = () => {} }: TagProps) {
+  const theme = useTheme();
+  const backGroundColor = useRef(selectRandomColor(theme, ['gray01', 'gray02', 'gray03']));
 
-export default function Tag({
-  content,
-  deletable = false,
-  onDelete = () => {},
-  onClick = () => {},
-}: TagProps) {
   const onClickCloseIcon = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onDelete();
   };
   return (
-    <div css={tagCss} onClick={onClick}>
+    <div css={tagCss(theme, backGroundColor.current)} onClick={onClick}>
       #{content}
       {deletable && (
         <button css={closeButtonCss} onClick={onClickCloseIcon}>
@@ -32,14 +30,16 @@ export default function Tag({
   );
 }
 
-const tagCss = (theme: Theme) => css`
+export default React.memo(Tag);
+
+const tagCss = (theme: Theme, backGroundColor: string) => css`
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
   height: 24px;
   padding: 0 6px;
   border-radius: ${theme.borderRadius.default};
-  background-color: ${selectRandomColor(theme, ['gray01', 'gray02', 'gray03'])};
+  background-color: ${backGroundColor};
   font-weight: 500;
   font-size: 10px;
   line-height: 150%;

--- a/src/hooks/api/tag/useTagMutation.ts
+++ b/src/hooks/api/tag/useTagMutation.ts
@@ -4,11 +4,6 @@ import { del, post } from '~/libs/api/client';
 
 import useTagRefresh from './useTagRefresh';
 
-interface CreateTagResponseInterface {
-  message: string;
-  data: CreateTagDataResponseInterface;
-}
-
 interface CreateTagDataResponseInterface {
   id: number;
   content: string;
@@ -17,14 +12,15 @@ interface CreateTagDataResponseInterface {
 export default function useTagMutation() {
   const { refresh } = useTagRefresh();
 
-  const createTagMutation = useMutation<CreateTagResponseInterface, { message?: string }, string>(
-    (content: string) => post<CreateTagResponseInterface>('/v1/tag/add', { content }),
-    {
-      onSuccess: () => {
-        refresh();
-      },
-    }
-  );
+  const createTagMutation = useMutation<
+    CreateTagDataResponseInterface,
+    { message?: string },
+    string
+  >((content: string) => post<CreateTagDataResponseInterface>('/v1/tag/add', { content }), {
+    onSuccess: () => {
+      refresh();
+    },
+  });
 
   const deleteTagMutation = useMutation((id: number) => del(`/v1/tag/remove/${id}`), {
     onSuccess: () => {


### PR DESCRIPTION
## ⛳️작업 내용
- `됫다고 쳐` 부분의 주석을 제거하고 create한 데이터를 onSave하도록 변경했습니다.
- CreateTagDataResponseInterface을 /v1/tag/add 리턴 타입에 맞게 변경했습니다.
- React.memo 작업과 첫 지정색으로 그리도록하는 작업을 진행했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/168322236-ee424f70-0259-47e3-b182-964c1fe903f0.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
###TagForm 에서  onSave에  tag create return data를 집어너어 바로추가하는 형태로 했습니다.
```tsx
const saveCreatedTag = useCallback(
  (keyword: string) => {
    createTag(keyword, {
      onSuccess: data => {
        onSave(data);
      },
    });
  },
  [createTag, onSave]
);
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
