### PR TITLE
영감 추가 후 메인 리스트 리프레시

### DIFF
--- a/src/hooks/api/inspiration/useGetInspirationListWIthInfinite.ts
+++ b/src/hooks/api/inspiration/useGetInspirationListWIthInfinite.ts
@@ -13,7 +13,7 @@ interface InspirationResponseInterface extends PaginationInterface {
 }
 
 // TODO: 추가, 삭제, 수정 등 Mutation과 맞추기
-const INSPIRATION_LIST_QUERY_KEY = 'inspirationList';
+export const INSPIRATION_LIST_QUERY_KEY = 'inspirationList';
 
 interface UseGetInspirationListWithInfiniteProps {
   filteredTags: TagType[];

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -1,8 +1,10 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { post } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
+
+import { INSPIRATION_LIST_QUERY_KEY } from './useGetInspirationListWIthInfinite';
 
 export interface InspirationMutationRequest {
   content?: string;
@@ -13,14 +15,19 @@ export interface InspirationMutationRequest {
 }
 
 export default function useInspirationMutation() {
+  const queryClient = useQueryClient();
   const { push } = useInternalRouter();
   const { fireToast } = useToast();
+  const resetInspirationList = () => {
+    queryClient.resetQueries(INSPIRATION_LIST_QUERY_KEY);
+  };
+
   const createInspirationMutation = useMutation(
     (data: FormData) => post('/v1/inspiration/add', data),
     {
       onSuccess: () => {
         fireToast({ content: '영감이 등록되었습니다!' });
-        // TODO: main 전체 invalidate (tag?)
+        resetInspirationList();
         push('/');
       },
       onError: (error, variable, context) => {


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### [feat: 영감 추가 시 inspiration list reset](https://github.com/depromeet/11th_7team_web/commit/7af3db14c5f1fc26e271f82158e573eef6454a0f)

영감 추가 후 메인 페이지로 돌아가면서 기존 cache를 리셋하고 다시 받아옵니다.

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
