### PR TITLE
회원가입 - api mutation & 기능 연동

### DIFF
--- a/src/hooks/api/auth/useCheckEmailVerifiedStatusMutation.ts
+++ b/src/hooks/api/auth/useCheckEmailVerifiedStatusMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQuery } from 'react-query';
+
+import { get } from '~/libs/api/client';
+
+export interface CheckEmailVerifiedStatusMutationParams {
+  email: string;
+}
+
+export interface CheckEmailVerifiedStatusMutationResponse {
+  message: string;
+  data: boolean;
+}
+
+/**
+ * `/api/v1/auth/email/{email}/status`
+ *
+ * 해당 이메일의 인증 상태 여부 반환
+ */
+export default function useCheckEmailVerifiedStatusMutation() {
+  return useMutation<
+    CheckEmailVerifiedStatusMutationResponse,
+    { message?: string },
+    CheckEmailVerifiedStatusMutationParams
+  >(({ email }: CheckEmailVerifiedStatusMutationParams) =>
+    get<CheckEmailVerifiedStatusMutationResponse>(`/v1/auth/email/${email}/status`)
+  );
+}

--- a/src/hooks/api/auth/useSignupSendEmailMutation.ts
+++ b/src/hooks/api/auth/useSignupSendEmailMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation } from 'react-query';
+
+import { post } from '~/libs/api/client';
+
+export interface SignupSendEmailMutationRequest {
+  email: string;
+}
+
+/**
+ * 회원가입을 위해 이메일에 인증 링크를 요청한다
+ */
+export default function useSignupSendEmailMutation() {
+  return useMutation<undefined, { message?: string }, SignupSendEmailMutationRequest>(
+    (data: SignupSendEmailMutationRequest) => post<undefined>('/v1/auth/sends-email', data)
+  );
+}

--- a/src/hooks/api/sign-up/useCheckExistsNicknameMutation.ts
+++ b/src/hooks/api/sign-up/useCheckExistsNicknameMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from 'react-query';
+
+import { post } from '~/libs/api/client';
+
+export interface CheckExistsNicknameMutationParams {
+  nickname: string;
+}
+
+export interface CheckExistsNicknameMutationResponse {
+  message: string;
+  data: null;
+}
+
+export default function useCheckExistsNicknameMutation() {
+  return useMutation<
+    CheckExistsNicknameMutationResponse,
+    { message?: string },
+    CheckExistsNicknameMutationParams
+  >(({ nickname }: CheckExistsNicknameMutationParams) =>
+    post<CheckExistsNicknameMutationResponse>(`/v1/signup/nicknames/${nickname}/exists`)
+  );
+}

--- a/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
+++ b/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
@@ -1,0 +1,25 @@
+import { useMutation } from 'react-query';
+
+import { post } from '~/libs/api/client';
+
+export interface CheckExistsSignupMutationParams {
+  email: string;
+}
+
+export interface CheckExistsSignupMutationResponse {
+  message: string;
+  data: boolean;
+}
+
+/**
+ * 해당 유저가 가입되어 있는 유저인지 상태 여부를 반환한다.
+ */
+export default function useCheckExistsSignupMutation() {
+  return useMutation<
+    CheckExistsSignupMutationResponse,
+    { message?: string },
+    CheckExistsSignupMutationParams
+  >(({ email }: CheckExistsSignupMutationParams) =>
+    post<CheckExistsSignupMutationResponse>(`/v1/signup/${email}/status`)
+  );
+}

--- a/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
+++ b/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from 'react-query';
 
-import { post } from '~/libs/api/client';
+import { get } from '~/libs/api/client';
 
 export interface CheckExistsSignupMutationParams {
   email: string;
@@ -20,6 +20,6 @@ export default function useCheckExistsSignupMutation() {
     { message?: string },
     CheckExistsSignupMutationParams
   >(({ email }: CheckExistsSignupMutationParams) =>
-    post<CheckExistsSignupMutationResponse>(`/v1/signup/${email}/status`)
+    get<CheckExistsSignupMutationResponse>(`/v1/signup/${email}/status`)
   );
 }

--- a/src/hooks/api/sign-up/useSignupMutation.ts
+++ b/src/hooks/api/sign-up/useSignupMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from 'react-query';
+
+import { post } from '~/libs/api/client';
+
+export interface SignupMutationParams {
+  email: string;
+  nickName: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export type SignupMutationResponse = string;
+
+/**
+ * `/api/v1/signup`
+ *
+ * 회원가입을 합니다.
+ */
+export default function useSignupMutation() {
+  return useMutation<SignupMutationResponse, { message?: string }, SignupMutationParams>(
+    (data: SignupMutationParams) => post<SignupMutationResponse>(`/v1/signup`, data)
+  );
+}

--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -10,7 +10,11 @@ export type RouterPathType =
   | '/add/image'
   | '/add/tag'
   | '/my'
-  | '/my/tag';
+  | '/my/tag'
+  | '/login'
+  | '/signup'
+  | '/signup/sent-email'
+  | '/signup/email-verified';
 
 export default function useInternalRouter() {
   const router = useRouter();

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -103,7 +103,10 @@ export default function Login() {
       </form>
       <GhostButton>비밀번호 찾기</GhostButton>
       <div css={signUpTextWrapperCss}>
-        계정이 없으신가요? <GhostButton size={'small'}>빠르게 가입하기</GhostButton>
+        계정이 없으신가요?{' '}
+        <GhostButton size={'small'} onClick={() => push('/signup')}>
+          빠르게 가입하기
+        </GhostButton>
       </div>
     </article>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -81,8 +81,8 @@ export default function Login() {
         <TextField
           label={'이메일 아이디'}
           placeholder={'이메일을 입력해주세요'}
-          feedback={emailError || <>&nbsp;</>}
-          isSuccess={!emailError}
+          feedback={email.value !== '' ? emailError || <>&nbsp;</> : <>&nbsp;</>}
+          isSuccess={emailError === ''}
           value={email.value}
           onChange={email.onChange}
           required
@@ -91,8 +91,8 @@ export default function Login() {
           type={'password'}
           label={'비밀번호'}
           placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
-          feedback={passwordError || <>&nbsp;</>}
-          isSuccess={!passwordError}
+          feedback={password.value !== '' ? passwordError || <>&nbsp;</> : <>&nbsp;</>}
+          isSuccess={passwordError === ''}
           value={password.value}
           onChange={password.onChange}
           required

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -1,58 +1,168 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { css, Theme } from '@emotion/react';
 
 import { CTABottomButton } from '~/components/common/Button';
 import CheckList from '~/components/common/CheckList';
+import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
+import { FixedSpinner } from '~/components/common/Spinner';
 import TextField from '~/components/common/TextField';
+import useSignupMutation from '~/hooks/api/sign-up/useSignupMutation';
+import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
+import { useToast } from '~/store/Toast';
+import { validator } from '~/utils/validator';
 
 export default function SignUpEmailVerified() {
+  const { fireToast } = useToast();
+  const { query } = useRouter();
+
   const nickname = useInput({ useDebounce: true });
   const password = useInput({ useDebounce: true });
   const passwordRepeat = useInput({ useDebounce: true });
+  const [nicknameError, setNicknameError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [passwordRepeatError, setPasswordRepeatError] = useState('');
+
+  const [checkTerms, setCheckTerms] = useState(false);
+  const [checkPrivacy, setCheckPrivacy] = useState(false);
+
+  const {
+    mutate: signupMutate,
+    isSuccess: signupSuccess,
+    error: signupError,
+    isLoading: signupLoading,
+  } = useSignupMutation();
+
+  const handleSignupSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!validator({ type: 'email', value: query.email as string })) {
+      return fireToast({ content: '이메일이 올바르지 않습니다. 처음부터 다시 시작해주세요.' });
+    }
+
+    if (nicknameError !== '' || passwordError !== '' || passwordRepeatError !== '') {
+      return fireToast({ content: '모든 입력 값을 적어주세요.' });
+    }
+
+    if (!checkTerms && !checkPrivacy) {
+      return fireToast({ content: '모두 동의해야 가입할 수 있습니다.' });
+    }
+
+    signupMutate({
+      email: query.email as string,
+      nickName: nickname.value,
+      password: password.value,
+      confirmPassword: passwordRepeat.value,
+    });
+  };
+
+  useDidUpdate(() => {
+    if (nickname.debouncedValue.length >= 4 && nickname.debouncedValue.length <= 20) {
+      setNicknameError('');
+    } else {
+      setNicknameError('닉네임은 4자 이상 20자 이하여야 합니다.');
+    }
+  }, [nickname.debouncedValue]);
+
+  useDidUpdate(() => {
+    if (password.debouncedValue.length >= 6) {
+      if (
+        validator({
+          rule: /^(?=.*[A-Za-z])(?=.*\d)[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]*$/,
+          value: password.debouncedValue,
+        })
+      ) {
+        setPasswordError('');
+      } else {
+        setPasswordError('비밀번호는 영문과 숫자를 모두 포함하여야 합니다.');
+      }
+    } else {
+      setPasswordError('비밀번호는 6자리 이상이여야 합니다.');
+    }
+  }, [password.debouncedValue]);
+
+  useDidUpdate(() => {
+    if (
+      passwordRepeat.debouncedValue.length > 0 &&
+      passwordRepeat.debouncedValue === password.value
+    ) {
+      setPasswordRepeatError('');
+    } else {
+      setPasswordRepeatError('비밀번호와 일치하여야 합니다.');
+    }
+  }, [passwordRepeat.debouncedValue]);
+
+  useEffect(() => {
+    if (signupSuccess) {
+      // TODO: router.push가 안되는 문제 해결하기
+      window.location.replace('/login');
+    }
+  }, [push, signupSuccess]);
+
+  useEffect(() => {
+    if (signupError) {
+      fireToast({ content: signupError.message ?? '회원가입 도중 문제가 발생하였습니다.' });
+    }
+  }, [fireToast, signupError]);
 
   return (
-    <article css={containerCss}>
-      <NavigationBar title={'회원가입'} />
-      <p css={introTextWrapper}>마지막 단계입니다!</p>
-      <form css={formCss}>
-        <fieldset css={fieldSetCss}>
-          <TextField
-            label={'닉네임'}
-            placeholder={'닉네임을 입력해주세요'}
-            feedback={<>&nbsp;</>}
-            value={nickname.value}
-            onChange={nickname.onChange}
-            required
-          />
-          <TextField
-            label={'비밀번호'}
-            placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
-            feedback={<>&nbsp;</>}
-            value={password.value}
-            onChange={password.onChange}
-            required
-          />
-          <TextField
-            label={'비밀번호 확인'}
-            placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
-            feedback={<>&nbsp;</>}
-            value={passwordRepeat.value}
-            onChange={passwordRepeat.onChange}
-            required
-          />
-          <div css={checkListWrapperCss}>
-            <CheckList isChecked={false} onToggle={() => {}}>
-              (필수) 서비스 이용약관에 동의
-            </CheckList>
-            <CheckList isChecked={false} onToggle={() => {}}>
-              (필수) 개인정보 수집 이용에 동의
-            </CheckList>
-          </div>
-        </fieldset>
-        <CTABottomButton type={'submit'}>Start Tang!</CTABottomButton>
-      </form>
-    </article>
+    <LoadingHandler
+      isLoading={!query || !Boolean(query.email) || query.email === undefined}
+      loadingComponent={<FixedSpinner />}
+    >
+      <article css={containerCss}>
+        <NavigationBar title={'회원가입'} />
+        <p css={introTextWrapper}>마지막 단계입니다!</p>
+        <form css={formCss} onSubmit={handleSignupSubmit}>
+          <fieldset css={fieldSetCss}>
+            <TextField
+              label={'닉네임'}
+              placeholder={'닉네임을 입력해주세요'}
+              feedback={nickname.value !== '' ? nicknameError || <>&nbsp;</> : <>&nbsp;</>}
+              isSuccess={nicknameError === ''}
+              value={nickname.value}
+              onChange={nickname.onChange}
+              required
+            />
+            <TextField
+              type="password"
+              label={'비밀번호'}
+              placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
+              feedback={password.value !== '' ? passwordError || <>&nbsp;</> : <>&nbsp;</>}
+              isSuccess={passwordError === ''}
+              value={password.value}
+              onChange={password.onChange}
+              required
+            />
+            <TextField
+              type="password"
+              label={'비밀번호 확인'}
+              placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
+              feedback={
+                passwordRepeat.value !== '' ? passwordRepeatError || <>&nbsp;</> : <>&nbsp;</>
+              }
+              isSuccess={passwordRepeatError === ''}
+              value={passwordRepeat.value}
+              onChange={passwordRepeat.onChange}
+              required
+            />
+            <div css={checkListWrapperCss}>
+              <CheckList isChecked={checkTerms} onToggle={() => setCheckTerms(!checkTerms)}>
+                (필수) 서비스 이용약관에 동의
+              </CheckList>
+              <CheckList isChecked={checkPrivacy} onToggle={() => setCheckPrivacy(!checkPrivacy)}>
+                (필수) 개인정보 수집 이용에 동의
+              </CheckList>
+            </div>
+          </fieldset>
+          <CTABottomButton type={'submit'} disabled={signupLoading}>
+            Start Tang!
+          </CTABottomButton>
+        </form>
+      </article>
+    </LoadingHandler>
   );
 }
 

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -99,7 +99,7 @@ export default function SignUpEmailVerified() {
       // TODO: router.push가 안되는 문제 해결하기
       window.location.replace('/login');
     }
-  }, [push, signupSuccess]);
+  }, [signupSuccess]);
 
   useEffect(() => {
     if (signupError) {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -3,10 +3,17 @@ import { css, Theme } from '@emotion/react';
 import { CTAButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
 import TextField from '~/components/common/TextField';
+import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
 import useInput from '~/hooks/common/useInput';
 
 export default function Signup() {
   const email = useInput({ useDebounce: true });
+  const {
+    mutate: emailSendMutate,
+    data: emailSendedData,
+    error: emailSendedError,
+    isLoading: emailSendingLoading,
+  } = useSignupSendEmailMutation();
 
   return (
     <article css={loginCss}>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,19 +1,85 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { css, Theme } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
 import TextField from '~/components/common/TextField';
 import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
+import useCheckExistsSignupMutation from '~/hooks/api/sign-up/useCheckExistsSignupMutation';
+import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
+import { useToast } from '~/store/Toast';
+import { validator } from '~/utils/validator';
 
 export default function Signup() {
+  const { fireToast } = useToast();
   const email = useInput({ useDebounce: true });
+  const { push } = useRouter();
+  const [emailError, setEmailError] = useState('');
   const {
     mutate: emailSendMutate,
-    data: emailSendedData,
     error: emailSendedError,
+    isSuccess: emailSendingSuccess,
     isLoading: emailSendingLoading,
   } = useSignupSendEmailMutation();
+  const {
+    mutate: checkExistsUserMutate,
+    data: checkExistsUserData,
+    error: checkExistsUserError,
+    isLoading: checkExistsUserLoading,
+  } = useCheckExistsSignupMutation();
+
+  const handleEmailSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (emailError !== '') {
+      return fireToast({ content: '입력한 값이 올바른지 확인해주세요.' });
+    }
+    checkExistsUserMutate({ email: email.value });
+  };
+
+  useDidUpdate(() => {
+    if (!validator({ type: 'email', value: email.debouncedValue })) {
+      setEmailError('올바른 이메일을 입력해주세요.');
+    } else {
+      setEmailError('');
+    }
+  }, [email.debouncedValue]);
+
+  useEffect(() => {
+    if (checkExistsUserData) {
+      if (!checkExistsUserData.data) {
+        emailSendMutate({ email: email.value });
+      } else {
+        fireToast({ content: '이미 가입된 사용자입니다!' });
+      }
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkExistsUserData]);
+
+  useEffect(() => {
+    if (emailSendingSuccess) {
+      push({
+        pathname: '/signup/sent-email',
+        query: {
+          email: email.value,
+        },
+      });
+    }
+  }, [email.value, emailSendingSuccess, push]);
+
+  useEffect(() => {
+    if (emailSendedError && emailSendedError.message) {
+      fireToast({ content: emailSendedError.message });
+    }
+  }, [emailSendedError, fireToast]);
+
+  useEffect(() => {
+    if (checkExistsUserError) {
+      fireToast({ content: '유저 검사 도중 문제가 발생하였습니다.' });
+    }
+  }, [checkExistsUserError, fireToast]);
 
   return (
     <article css={loginCss}>
@@ -26,15 +92,18 @@ export default function Signup() {
           영감을 차곡차곡 쌓아갈 수 있어요.
         </p>
       </div>
-      <form css={fieldSetCss}>
+      <form css={fieldSetCss} onSubmit={handleEmailSubmit}>
         <TextField
           placeholder={'이메일을 입력해주세요'}
-          feedback={<>&nbsp;</>}
           value={email.value}
           onChange={email.onChange}
+          feedback={email.value !== '' ? emailError || <>&nbsp;</> : <>&nbsp;</>}
+          isSuccess={emailError === ''}
           required
         />
-        <CTAButton type={'submit'}>로그인</CTAButton>
+        <CTAButton type={'submit'} disabled={emailSendingLoading || checkExistsUserLoading}>
+          로그인
+        </CTAButton>
       </form>
       <div css={signUpTextWrapperCss}>
         입력한 이메일은 홍보/마케팅 용으로 사용되지 않고,

--- a/src/remotes/auth.d.ts
+++ b/src/remotes/auth.d.ts
@@ -6,5 +6,3 @@ interface AuthTokenResponseInterface {
     accessTokenExpireDate: string;
   };
 }
-
-interface AuthEmailStatusInterface {}

--- a/src/remotes/auth.d.ts
+++ b/src/remotes/auth.d.ts
@@ -6,3 +6,5 @@ interface AuthTokenResponseInterface {
     accessTokenExpireDate: string;
   };
 }
+
+interface AuthEmailStatusInterface {}


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- login
  - 로그인 폼 초기 상태에서 체크 표시 수정
- signup
  - 이메일 가입 여부 확인 후 메일 전송 뮤테이션 적용
- signup/sent-email
  - 이메일 승인 여부 확인 후 모달 띄우기 구현
- signup/email-verified
  - 가입 완료 로직
  - 문제점1: signupSuccess effect 안에서 router.push가 안됩니다. 정확히는 주소는 변경되는데, 페이지 리프레시가 일어나지 않아요. memo 같은 것을 사용한 것도 아니라서 추후에 디버깅이 필요합니다 ㅠㅠ
    - 해당 문제는 우선 window.location.replace()로 구현해놨어요

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->