### PR TITLE
태그 필터 화면 완료 버튼 추가 및 useInternalRouter 추가 기능 개발

### DIFF
--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -25,6 +25,13 @@ export default function useInternalRouter() {
       push(path: RouterPathType, as?: UrlObject | string, options?: TransitionOptions) {
         router.push(path, as, options);
       },
+      scrollPreventedPush(
+        path: RouterPathType,
+        as?: UrlObject | string,
+        options?: Omit<TransitionOptions, 'scroll'>
+      ) {
+        router.push(path, as, { ...options, scroll: false });
+      },
     };
   }, [router]);
 }

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 
+import { GhostButton } from '~/components/common/Button';
 import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
 import { FixedSpinner } from '~/components/common/Spinner';
 import TagForm from '~/components/TagForm';
 import { defaultFadeInVariants } from '~/constants/motions';
 import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useFilteredTags } from '~/store/FilteredTags';
 
 export default function TagPage() {
@@ -14,9 +16,24 @@ export default function TagPage() {
   const [keyword, setKeyword] = useState('');
   const { tags, isLoading } = useGetTagListWithInfinite({ keyword });
 
+  const router = useInternalRouter();
+
+  const onClickComplete = () => {
+    router.scrollPreventedPush('/');
+  };
+
   return (
     <article>
-      <NavigationBar title="태그 필터" backLink="/" backLinkScrollOption={false} />
+      <NavigationBar
+        title="태그 필터"
+        backLink="/"
+        backLinkScrollOption={false}
+        rightElement={
+          <GhostButton size="large" onClick={onClickComplete}>
+            완료
+          </GhostButton>
+        }
+      />
 
       <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
         <motion.div


### PR DESCRIPTION
## ⛳️작업 내용

- 홈 태그 필터 화면에 기획상 존재하였던 완료 버튼을 추가했어요
- RouteAsModal과 같이 사용될 때, 다양한 부분에서 `scroll: false`로 push를 할 수 있다는 생각에, 
  `useInternalRouter`에 `scrollPreventedPush`를 추가해봤어요

## 📸스크린샷

<img width="364" alt="스크린샷 2022-05-16 오후 1 45 27" src="https://user-images.githubusercontent.com/26461307/168521404-3a3decd3-ea44-4135-b406-f21140e7891b.png">


## ⚡️사용 방법

```jsx
const router = useInternalRouter();

router.scrollPreventedPush('/');
// router.push('/', undefined, {scroll: false}); 와 동일
```

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
