### PR TITLE
홈 화면 Empty 이미지 렌더링 문제 해결

### DIFF
--- a/src/components/common/LoadingHandler/LoadingHandler.tsx
+++ b/src/components/common/LoadingHandler/LoadingHandler.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, ReactElement, useId } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
-interface LoadingHandler {
+interface LoadingHandlerProps {
   isLoading: boolean;
   loadingComponent: ReactElement;
 }
@@ -10,7 +10,7 @@ function LoadingHandler({
   children,
   isLoading,
   loadingComponent,
-}: PropsWithChildren<LoadingHandler>) {
+}: PropsWithChildren<LoadingHandlerProps>) {
   const id = useId();
 
   return (

--- a/src/components/home/EmptyImageSection.tsx
+++ b/src/components/home/EmptyImageSection.tsx
@@ -6,7 +6,7 @@ import { defaultFadeInScaleVariants, staggerOne } from '~/constants/motions';
 
 export default function EmptyImageSection() {
   return (
-    <motion.div
+    <motion.section
       css={imageWrapperCss}
       variants={staggerOne}
       initial="initial"
@@ -25,7 +25,7 @@ export default function EmptyImageSection() {
         alt="empty inspiration"
         variants={defaultFadeInScaleVariants}
       />
-    </motion.div>
+    </motion.section>
   );
 }
 


### PR DESCRIPTION
## ⛳️작업 내용

- 홈 화면에서 "영감에 부착된 태그 선택" 후 "영감에 부착되지 않은 태그 선택했을 시" 이미지가 렌더링되지 않는 문제를 해결했어요
- `useGetInspirationListWithInfinite` hook에서 `isEmpty`를 내려보내도록 리팩토링 했어요

가장 공유하고 싶은 이슈는 `AnimatePresence` 관련 이슈임니다

현재 해결 방법으로 2가지가 있는데, (문제점은 이슈에 적어 두었어요 #224 )

1. 삼항 연산자를 이용해 컨디셔널 렌더링 

```diff
+ empty일 때 썸네일 wrapper section 태그가 렌더링되지 않음
- 이미지의 exit 애니메이션이 발생하지 않음 (이미지 컴포넌트에 key 값을 적용하지 않아서)
```

```jsx
{isEmpty ? (
            <EmptyImageSection />
          ) : (
            <motion.section
              css={thumbnailWrapperCss}
              layout
              layoutId="thumbnailSection"
              variants={staggerHalf}
              initial="initial"
              animate="animate"
              exit="exit"
            >
           {...}
            </motion.section>
          )}
```

2. 이미지에만 컨디셔널 렌더링을 적용

```diff
+ 이미지의 exit 애니메이션이 발생함
- empty일 때 썸네일 wrapper section이 렌더링됨 (물론 썸네일은 렌더링되지 않고, section 태그만 렌더링됨)
```

```jsx
         {isEmpty && <EmptyImageSection key="loading section" />}
          <motion.section
            css={thumbnailWrapperCss}
            layout
            layoutId="thumbnailSection"
            variants={staggerHalf}
            initial="initial"
            animate="animate"
            exit="exit"
          >
          {...}
            {hasNextPage && !isLoading && <div ref={setTarget}></div>}
          </motion.section>
```

**현재는 exit 애니메이션을 발생하는 방향으로 작성해두었어요.** 

## 📸스크린샷

- 1번 방법 (exit X)

https://user-images.githubusercontent.com/26461307/168625022-0579a759-575d-4b7e-8ae2-b57eafbab71a.mov

- 2번 방법 (exit O)

https://user-images.githubusercontent.com/26461307/168625112-1dc52b5a-0543-47b6-87e3-6f56940b28b7.mov



## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스



[`AnimatePresence`는 직계 자손 노드만 exit 애니메이션을 재생한다고 합니다](https://www.framer.com/docs/animate-presence/)

직계 자손 노드가 children으로 맵핑되어 발생한 버그같아요. 
자세한 내용은 framer motion 레포에 질문을 올려보거나 이슈를 더욱 발굴해 공유드릴 수 있도록 하겟슴다

무엇이 문제일지 감을 잡을려 발굴중인 샌드박스 링크 첨부해드립니다.... 사실 아직도 정확히 무엇이 문제인지는 ...
https://codesandbox.io/s/sweet-fast-vvotop?file=/src/pages/index.tsx
