### PR TITLE
styles utils 리팩토링 및 테스트 코드 작성

### DIFF
--- a/src/__test__/utils/getStyleValueFromSerializedStyles.ts
+++ b/src/__test__/utils/getStyleValueFromSerializedStyles.ts
@@ -1,0 +1,14 @@
+import { SerializedStyles } from '@emotion/react';
+
+export function getStyleValueFromSerializedStyles(styles: SerializedStyles, key: string) {
+  const splitedStyles = styles.styles.split(`\n`).map(each => each.trim());
+  const attributePair = splitedStyles.filter(each => {
+    const [eachKey] = each.split(':');
+    if (eachKey === key) return true;
+  });
+
+  if (typeof attributePair[0] === 'undefined') return undefined;
+
+  const styleValue = attributePair[0].split(':')[1].replace(';', '').trim();
+  return styleValue;
+}

--- a/src/__test__/utils/index.ts
+++ b/src/__test__/utils/index.ts
@@ -1,1 +1,2 @@
 export { customRender } from './customRender';
+export { getStyleValueFromSerializedStyles } from './getStyleValueFromSerializedStyles';

--- a/src/components/LinkThumbnail.tsx
+++ b/src/components/LinkThumbnail.tsx
@@ -1,6 +1,6 @@
 import { css, Theme } from '@emotion/react';
 
-import textEllipisCss from '~/styles/utils/textEllipisCss';
+import { textEllipsisCss } from '~/styles/utils';
 
 import { IconButton } from './common/Button';
 
@@ -81,7 +81,7 @@ const linkThumbnailTitleCss = css`
   font-size: 12px;
   line-height: 150%;
 
-  ${textEllipisCss(3)}
+  ${textEllipsisCss(3)}
 `;
 
 const linkThumbnailUrlCss = (theme: Theme) => css`
@@ -90,7 +90,7 @@ const linkThumbnailUrlCss = (theme: Theme) => css`
   line-height: 150%;
   color: ${theme.color.gray03};
 
-  ${textEllipisCss(1)}
+  ${textEllipsisCss(1)}
 `;
 
 const linkThumbnailImageCss = (theme: Theme) => css`

--- a/src/components/common/Spinner/FixedSpinner.tsx
+++ b/src/components/common/Spinner/FixedSpinner.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 
+import { fullViewHeight } from '~/styles/utils';
+
 import Spinner from './Spinner';
 
 export function FixedSpinner() {
@@ -15,7 +17,7 @@ const wrapperCss = css`
   left: 0;
   top: 0;
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  height: ${fullViewHeight()};
 
   display: flex;
   justify-content: center;

--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -1,7 +1,7 @@
 import { SyntheticEvent, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
-import textEllipisCss from '~/styles/utils/textEllipisCss';
+import { textEllipsisCss } from '~/styles/utils';
 
 import { ContentThumbnailProps } from './Thumbnail';
 
@@ -51,7 +51,7 @@ const linkTextWrapperCss = (theme: Theme) => css`
   overflow: hidden;
 
   & p {
-    ${textEllipisCss(1)}
+    ${textEllipsisCss(1)}
   }
 `;
 

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -10,6 +10,7 @@ import useImgUpload from '~/hooks/common/useImgUpload';
 import useInput from '~/hooks/common/useInput';
 import { useInspirationDetail } from '~/store/Inspiration';
 import { useUploadedImg } from '~/store/UploadedImage';
+import { fullViewHeight } from '~/styles/utils';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
@@ -74,12 +75,12 @@ const addImageCss = css`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: calc(var(--vh, 1vh) * 100 - 44px);
+  height: calc(${fullViewHeight()} - 44px);
   overflow: hidden;
 `;
 
 export const formCss = css`
-  height: calc(var(--vh, 1vh) * 100 - 44px);
+  height: calc(${fullViewHeight()} - 44px);
   display: flex;
   flex-direction: column;
 `;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import { queryClient } from '~/libs/api/queryClient';
 import { UserProvider } from '~/store/User/UserProvider';
 import GlobalStyle from '~/styles/GlobalStyle';
 import CustomTheme from '~/styles/Theme';
+import { fullViewHeight } from '~/styles/utils';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -31,13 +32,13 @@ export default function App({ Component, pageProps }: AppProps) {
   );
 }
 
+let vh = 0;
+
 /**
  * 레이아웃 컴포넌트입니다.
  *
  * `_app`에서만 사용되는 컴포넌트이기에, 인라인으로 작성되었습니다.
  */
-let vh = 0;
-
 function Layout({ children }: PropsWithChildren<{}>) {
   const windowSize = useWindowSize();
 
@@ -50,7 +51,7 @@ function Layout({ children }: PropsWithChildren<{}>) {
 }
 
 const layoutCss = (theme: Theme) => css`
-  min-height: calc(var(--vh, 1vh) * 100);
+  min-height: ${fullViewHeight()};
   background: ${theme.color.background};
   max-width: ${theme.size.maxWidth};
   width: 100%;

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -14,6 +14,7 @@ import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useUploadedImg } from '~/store/UploadedImage';
+import { fullViewHeight } from '~/styles/utils';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
@@ -90,12 +91,12 @@ export default function AddImage() {
 const addImageCss = css`
   display: flex;
   flex-direction: column;
-  height: calc(var(--vh, 1vh) * 100);
+  height: ${fullViewHeight()};
   overflow: hidden;
 `;
 
 export const formCss = css`
-  height: calc(var(--vh, 1vh) * 100 - 44px);
+  height: calc(${fullViewHeight()} - 44px);
   display: flex;
   flex-direction: column;
 `;

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './textEllipsisCss';

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './textEllipsisCss';
+export * from './viewHeight';

--- a/src/styles/utils/textEllipsisCss/index.test.ts
+++ b/src/styles/utils/textEllipsisCss/index.test.ts
@@ -1,0 +1,7 @@
+import { textEllipsisCss } from './index';
+
+describe('styles/utils/textEllipsisCss/index', () => {
+  it('should define', () => {
+    expect(textEllipsisCss).toBeDefined();
+  });
+});

--- a/src/styles/utils/textEllipsisCss/index.ts
+++ b/src/styles/utils/textEllipsisCss/index.ts
@@ -1,0 +1,1 @@
+export { textEllipsisCss } from './textEllipsisCss';

--- a/src/styles/utils/textEllipsisCss/textEllipsisCss.test.ts
+++ b/src/styles/utils/textEllipsisCss/textEllipsisCss.test.ts
@@ -1,0 +1,18 @@
+import { getStyleValueFromSerializedStyles } from '~/__test__/utils';
+
+import { textEllipsisCss } from './textEllipsisCss';
+
+const CSS_ATTRIBUTE = '-webkit-line-clamp';
+
+describe('styles/utils/textEllipsisCss', () => {
+  it('should defined', () => {
+    expect(textEllipsisCss).toBeDefined();
+  });
+
+  it('should return correct line clamp value', () => {
+    const expectNumber = 1;
+    const result = textEllipsisCss(expectNumber);
+    const lineClampValue = getStyleValueFromSerializedStyles(result, CSS_ATTRIBUTE);
+    expect(lineClampValue).toBe(expectNumber.toString());
+  });
+});

--- a/src/styles/utils/textEllipsisCss/textEllipsisCss.ts
+++ b/src/styles/utils/textEllipsisCss/textEllipsisCss.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-export default function textEllipisCss(line: number) {
+export function textEllipsisCss(line: number) {
   return css`
     display: -webkit-box;
     -webkit-line-clamp: ${line};

--- a/src/styles/utils/viewHeight/index.test.ts
+++ b/src/styles/utils/viewHeight/index.test.ts
@@ -1,0 +1,11 @@
+import { fullViewHeight, viewHeight } from './index';
+
+describe('styles/utils/viewHeight/index', () => {
+  it('should defined viewHeight', () => {
+    expect(viewHeight).toBeDefined();
+  });
+
+  it('should defined fullViewHeight', () => {
+    expect(fullViewHeight).toBeDefined();
+  });
+});

--- a/src/styles/utils/viewHeight/index.ts
+++ b/src/styles/utils/viewHeight/index.ts
@@ -1,0 +1,1 @@
+export { fullViewHeight, viewHeight } from './viewHeight';

--- a/src/styles/utils/viewHeight/viewHeight.test.ts
+++ b/src/styles/utils/viewHeight/viewHeight.test.ts
@@ -1,0 +1,22 @@
+import { fullViewHeight, viewHeight } from './viewHeight';
+
+describe('styles/utils/viewHeight', () => {
+  it('should defined viewHeight', () => {
+    expect(viewHeight).toBeDefined();
+  });
+
+  it('should return correct viewHeight value from viewHeight util', () => {
+    const viewHeightValue = 50;
+    const result = viewHeight(viewHeightValue);
+    expect(result.includes(viewHeightValue.toString())).toBeTruthy();
+  });
+
+  it('should defined fullViewHeight', () => {
+    expect(fullViewHeight).toBeDefined();
+  });
+
+  it('should return 100 viewHeight from fullViewHeight util', () => {
+    const result = fullViewHeight();
+    expect(result.includes('100')).toBeTruthy();
+  });
+});

--- a/src/styles/utils/viewHeight/viewHeight.ts
+++ b/src/styles/utils/viewHeight/viewHeight.ts
@@ -1,0 +1,7 @@
+export function viewHeight(value: number) {
+  return `calc(var(--var, 1vh) * ${value})`;
+}
+
+export function fullViewHeight() {
+  return viewHeight(100);
+}


### PR DESCRIPTION
## ⛳️작업 내용

- `textEllipsisCss` 유틸의 디렉토리를 변경하면서 테스트 코드를 작성했어요
- emotion `SerializedStyles` 객체에서 속성 값을 반환하는 테스트용 유틸을 개발했어요
- 기존 은정님께서 작업해주신 `view height` 관련 로직을 유틸로 빼었어요. 이름은 `viewHeight`, `fullViewHeight`로 지었어요
- 위 유틸에 대해 테스트 코드를 작성했어요
- 위 유틸을 적용했어요

사용된 곳에 모두 적절히 보이는 지 확인하였어요. 미처 확인하지 못한 곳이 있을 시 말씀해주시면 제가 적용해볼게요. 👍 

## 📸스크린샷


## ⚡️사용 방법

- textEllipsisCss

```jsx
// 기존
import textEllipsisCss from '~/styles/utils/textEllipsisCss';

// 변경 후
import { textEllipsisCss } from '~/styles/utils';
```

- viewHeight, fullViewHeight

```jsx
import { viewHeight, fullViewHeight } from '~/styles/utils';

// 기존
const fooCss = css`
  height: calc(var(--var, 1vh) * 100));
`;

const barCss = css`
  height: calc(var(--var, 1vh) * 100) - 44px);
`;

// 적용 후
const fooCss = css`
  height: ${fullViewHeight()};
`;

const barCss = css`
  height: calc(${fullViewHeight()} - 44px);
`;
```



## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
