### PR TITLE
태그 필터, 영감 보기 스크롤 이슈 해결

### DIFF
--- a/src/components/add/AddTagFormRouteAsModal.tsx
+++ b/src/components/add/AddTagFormRouteAsModal.tsx
@@ -1,7 +1,6 @@
 import { css, Theme } from '@emotion/react';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
-import usePreventScroll from '~/hooks/common/usePreventScroll';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import TagPage from '~/pages/add/tag';
 
@@ -9,7 +8,7 @@ import TagPage from '~/pages/add/tag';
 
 export default function AddTagFormRouteAsModal() {
   const query = useQueryParam('modal', String);
-  usePreventScroll(query === 'addTag');
+
   return (
     <PortalWrapper isShowing={query === 'addTag'}>
       <div css={wrapperCss}>
@@ -28,7 +27,8 @@ const wrapperCss = (theme: Theme) => css`
 
   width: 100%;
   max-width: ${theme.size.maxWidth};
-  height: 100vh;
+  height: 100%;
+  overflow-y: scroll;
   background-color: ${theme.color.background};
   padding: ${theme.size.layoutPadding};
   z-index: 1000;

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -37,10 +37,12 @@ export default function NavigationBar({
   );
 }
 
-const navCss = css`
-  position: relative;
+const navCss = (theme: Theme) => css`
+  position: sticky;
+  top: 0;
   width: 100%;
   height: 44px;
+  background-color: ${theme.color.background};
 
   display: flex;
   justify-content: space-between;

--- a/src/components/home/TagFormRouteAsModal.tsx
+++ b/src/components/home/TagFormRouteAsModal.tsx
@@ -29,6 +29,7 @@ const wrapperCss = (theme: Theme) => css`
   width: 100%;
   max-width: ${theme.size.maxWidth};
   height: 100%;
+  overflow-y: scroll;
   background-color: ${theme.color.background};
   padding: ${theme.size.layoutPadding};
   z-index: 1000;

--- a/src/components/inspiration/InspirationViewAsModal.tsx
+++ b/src/components/inspiration/InspirationViewAsModal.tsx
@@ -27,7 +27,9 @@ const wrapperCss = (theme: Theme) => css`
   transform: translateX(-50%);
 
   width: 100%;
+  max-width: ${theme.size.maxWidth};
   height: 100%;
+  overflow-y: scroll;
   background-color: ${theme.color.background};
   padding: ${theme.size.layoutPadding};
   z-index: 1000;

--- a/src/pages/content/[contentId].tsx
+++ b/src/pages/content/[contentId].tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from 'react';
-import { css } from '@emotion/react';
 
 import { IconButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
@@ -39,7 +38,7 @@ export default function ContentPage() {
   const { id } = inspirationDetail;
 
   return (
-    <article css={contentCss}>
+    <article>
       <NavigationBar
         title=""
         backLink="/"
@@ -52,5 +51,3 @@ export default function ContentPage() {
     </article>
   );
 }
-
-const contentCss = css``;

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import { GhostButton } from '~/components/common/Button';
@@ -24,7 +23,7 @@ export default function TagPage() {
   };
 
   return (
-    <article css={wrapperCss}>
+    <article>
       <NavigationBar
         title="태그 필터"
         backLink="/"
@@ -58,8 +57,3 @@ export default function TagPage() {
     </article>
   );
 }
-
-const wrapperCss = css`
-  height: 100%;
-  overflow-y: scroll;
-`;

--- a/src/pages/tag/index.tsx
+++ b/src/pages/tag/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import { GhostButton } from '~/components/common/Button';
@@ -23,7 +24,7 @@ export default function TagPage() {
   };
 
   return (
-    <article>
+    <article css={wrapperCss}>
       <NavigationBar
         title="태그 필터"
         backLink="/"
@@ -57,3 +58,8 @@ export default function TagPage() {
     </article>
   );
 }
+
+const wrapperCss = css`
+  height: 100%;
+  overflow-y: scroll;
+`;


### PR DESCRIPTION
## ⛳️작업 내용

- `/tag` route 이자 `TagFormRouteAsModal`에서 스크롤이 가능하도록 하였어요

  (body는 스크롤 방지하며, Modal만 스크롤되게)

- 영감보기 화면에서 body가 스크롤되는 것을 방지했어요
  
  `AddTagFormRouteAsModal`의 `usePreventScroll`을 사용하지 않도록 했어요
  사이드 이펙트 확인했습니다

- NavigationBar를 `position: sticky`로 수정했어요
  
  스크롤 시 상단에 위치하기 위해서입니다. 사이드 이펙트 확인했어요


## 📸스크린샷

- 영감보기 스크롤 가능 + body 스크롤 방지

https://user-images.githubusercontent.com/26461307/169227284-7b1d74db-58ac-4342-910c-e29de744a37e.mov


- 태그 필터 스크롤 가능 + body 스크롤 방지

https://user-images.githubusercontent.com/26461307/169227393-27cec444-3b16-4b4d-8db7-fc9730867306.mov


- 태그 추가 스크롤 가능 + body 스크롤 방지

https://user-images.githubusercontent.com/26461307/169227428-78379ff7-26b1-4e09-9ff9-354b39477e0c.mov


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎 공유

`NavigationBar`의 경우 많이 사용하시고 계셔서 사이드 이펙트를 전부 확인한 것은 아니지만,

없을 것이라 생각해요! 하지만 혹시나 이슈가 있으실 시 말씀해주시면 제가 수정해보겠습니다 ~!

---

`RouteAsModal` 에서 `body`는 스크롤을 방지하며, Modal은 스크롤을 가능하게 할 시,

Modal의 최상위 wrapper에 높이와 `overflow-y` 옵션을 주면 되더라구요! 공유 드립니다 🙇 

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
