### PR TITLE
인증 토큰 만료 시 갱신 후 재요청

### DIFF
--- a/src/hooks/api/auth/useCheckEmailVerifiedStatusMutation.ts
+++ b/src/hooks/api/auth/useCheckEmailVerifiedStatusMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from 'react-query';
+import { useMutation } from 'react-query';
 
 import { get } from '~/libs/api/client';
 

--- a/src/hooks/common/useAuthorizationIntercept.ts
+++ b/src/hooks/common/useAuthorizationIntercept.ts
@@ -20,11 +20,6 @@ export default function useAuthorizationIntercept() {
     const axiosRejectedInterceptor = async (error: AxiosError) => {
       const status = error.response ? error.response.status : null;
 
-      // // response
-      // if (error.response?.data?.message) {
-      //   return Promise.reject(new Error(error.response?.data?.message));
-      // }
-
       if (status === 401 && !isPending) {
         const storedRefreshToken = getCookie(COOKIE_REFRESH);
         if (!storedRefreshToken) {

--- a/src/hooks/common/useAuthorizationIntercept.ts
+++ b/src/hooks/common/useAuthorizationIntercept.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { AxiosError } from 'axios';
+
+import { COOKIE_REFRESH } from '~/constants/common';
+import { instance, post, replaceResponseInterceptorForApiInstance } from '~/libs/api/client';
+import { useToast } from '~/store/Toast';
+import { useUser } from '~/store/User';
+
+import useCookie from './useCookie';
+import useInternalRouter from './useInternalRouter';
+
+export default function useAuthorizationIntercept() {
+  const { fireToast } = useToast();
+  const { get: getCookie, remove: removeCookie } = useCookie();
+  const { push } = useInternalRouter();
+  const { userLogin } = useUser();
+  const [isPending, setPending] = useState(false);
+
+  useEffect(() => {
+    const axiosRejectedInterceptor = async (error: AxiosError) => {
+      const status = error.response ? error.response.status : null;
+
+      // // response
+      // if (error.response?.data?.message) {
+      //   return Promise.reject(new Error(error.response?.data?.message));
+      // }
+
+      if (status === 401 && !isPending) {
+        const storedRefreshToken = getCookie(COOKIE_REFRESH);
+        if (!storedRefreshToken) {
+          return Promise.reject('로그인 하지 못했습니다.');
+        }
+        setPending(true);
+        try {
+          const { data } = await post<{ message: string; data: AuthTokenResponseInterface }>(
+            '/v1/reissue',
+            undefined,
+            {
+              headers: {
+                'REFRESH-TOKEN': storedRefreshToken,
+              },
+            }
+          );
+          setPending(false);
+          userLogin({ accessToken: data.accessToken, refreshToken: data.refreshToken });
+        } catch {
+          fireToast({ content: '세션이 만료되었습니다.' });
+          push('/login');
+          removeCookie(COOKIE_REFRESH);
+          setPending(false);
+          return Promise.reject('세션이 만료되었습니다.');
+        }
+
+        return instance.request(error.config);
+      }
+
+      return Promise.reject(new Error(error.response?.data?.message ?? error));
+    };
+
+    replaceResponseInterceptorForApiInstance({ rejected: axiosRejectedInterceptor });
+  }, [fireToast, getCookie, isPending, push, removeCookie, userLogin]);
+}

--- a/src/hooks/common/useAuthorizationIntercept.ts
+++ b/src/hooks/common/useAuthorizationIntercept.ts
@@ -20,39 +20,38 @@ export default function useAuthorizationIntercept() {
     const axiosRejectedInterceptor = async (error: AxiosError) => {
       const status = error.response ? error.response.status : null;
 
-      if (error.config.headers && status === 401 && !isPending) {
-        if (!refreshToken) {
-          // TODO: 추후 로그아웃(user/userLogout) 넣기
-          return Promise.reject('로그인 하지 못했습니다.');
-        }
-        setPending(true);
-        try {
-          const { data } = await post<{ message: string; data: AuthTokenResponseInterface }>(
-            '/v1/reissue',
-            undefined,
-            {
-              headers: {
-                'REFRESH-TOKEN': refreshToken,
-              },
-            }
-          );
-          setPending(false);
-          userLogin({ accessToken: data.accessToken, refreshToken: data.refreshToken });
-          error.config.headers['accessToken'] = data.accessToken;
-        } catch {
-          fireToast({ content: '세션이 만료되었습니다. 다시 로그인 해주세요.' });
+      if (!error.config.headers || status !== 401 || isPending)
+        return Promise.reject(new Error(error.response?.data?.message ?? error));
+      if (!refreshToken) {
+        // TODO: 추후 로그아웃(user/userLogout) 넣기
+        return Promise.reject('로그인 하지 못했습니다.');
+      }
+      setPending(true);
 
-          // TODO: 추후 로그아웃(user/userLogout)으로 대체
-          push('/login');
-          removeCookie(COOKIE_REFRESH);
-          setPending(false);
-          return Promise.reject('세션이 만료되었습니다.');
-        }
+      try {
+        const { data } = await post<{ message: string; data: AuthTokenResponseInterface }>(
+          '/v1/reissue',
+          undefined,
+          {
+            headers: {
+              'REFRESH-TOKEN': refreshToken,
+            },
+          }
+        );
+        setPending(false);
+        userLogin({ accessToken: data.accessToken, refreshToken: data.refreshToken });
+        error.config.headers['accessToken'] = data.accessToken;
+      } catch {
+        fireToast({ content: '세션이 만료되었습니다. 다시 로그인 해주세요.' });
 
-        return instance.request(error.config);
+        // TODO: 추후 로그아웃(user/userLogout)으로 대체
+        push('/onboard');
+        removeCookie(COOKIE_REFRESH);
+        setPending(false);
+        return Promise.reject('세션이 만료되었습니다.');
       }
 
-      return Promise.reject(new Error(error.response?.data?.message ?? error));
+      return instance.request(error.config);
     };
 
     replaceResponseInterceptorForApiInstance({ rejected: axiosRejectedInterceptor });

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 const developmentApiUrl = process.env.API_DEVELOPMENT ?? 'https://ygtang.kr/api';
 
@@ -8,17 +8,7 @@ export const instance = axios.create({
 });
 
 export function replaceAccessTokenForRequestInstance(token: string) {
-  // Request interceptor
-  function interceptorRequestFulfilled(config: AxiosRequestConfig) {
-    return {
-      ...config,
-      headers: {
-        accessToken: `${token}`,
-      },
-    };
-  }
-
-  instance.interceptors.request.use(interceptorRequestFulfilled);
+  instance.defaults.headers.common['accessToken'] = token;
 }
 
 // Response interceptor

--- a/src/pages/test/user.tsx
+++ b/src/pages/test/user.tsx
@@ -1,0 +1,20 @@
+import { CTAButton } from '~/components/common/Button';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { replaceAccessTokenForRequestInstance } from '~/libs/api/client';
+
+export default function UserTestPage() {
+  const { push } = useInternalRouter();
+  const makeExpireAccessToken = () => {
+    console.log('변경');
+
+    replaceAccessTokenForRequestInstance(
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sIm1lbWJlcl9pZCI6MywiaWF0IjoxNjUzMDczOTAyLCJleHAiOjE2NTMwNzc1MDJ9.hyMRA4fuQ4K91O-OtxnxtdYOXT-r_k0toNsHTomsLRs'
+    );
+  };
+  return (
+    <>
+      <CTAButton onClick={() => push('/')}>메인으로 가기</CTAButton>
+      <CTAButton onClick={makeExpireAccessToken}>accessToken 만료시키기</CTAButton>
+    </>
+  );
+}

--- a/src/store/User/UserProvider.tsx
+++ b/src/store/User/UserProvider.tsx
@@ -15,7 +15,6 @@ import { useUser } from './';
 
 export function UserProvider({ children }: PropsWithChildren<unknown>) {
   const { isLoaded, setIsLoaded, userLogin, userLogout, isLoggedIn } = useUser();
-  const { get: cookieGet, remove: cookieRemove } = useCookie();
   const { fireToast } = useToast();
   const { push } = useInternalRouter();
 

--- a/src/store/User/useUser.ts
+++ b/src/store/User/useUser.ts
@@ -43,5 +43,9 @@ export function useUser() {
     isLoaded,
     setIsLoaded,
     userLogin,
+    accessToken,
+    refreshToken,
+    setAccessToken,
+    setRefreshToken,
   };
 }


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- accessToken이 만료되었을 경우 axios interceptor를 통해서 갱신하는 로직을 만들었습니다.
  - react-query를 사용하고 싶었는데, interceptor 안에서 모든 작업을 끝내야될 것 같더라고요. (hooks 기반의 비동기 처리가 어렵습니다.) 그래서 post api instance를 직접 로직에서 사용하였습니다.
- 또한 위와 관련된 작업으로 api instance의 interceptor를 교체할 수 있도록 하였습니다.
- api instance의 accessToken은 인터셉터가 아니라, config로 처리할 수 있도록 변경하였습니다.
- 추후에 #246 에서 만든 userLogout 적용 예정입니다.
- /test/user 에 유저 관련 테스트를 도와주는 페이지를 만들었습니다.

> 관련되서 비슷한 작업을 해보신 분이라던가, 더 깔끔하게 처리할 수 있는 방법을 아시는 분들은 자유롭게 제안주셨으면 합니다~!!

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

<img width="483" alt="image" src="https://user-images.githubusercontent.com/6638675/169640443-31d98fae-39e8-4225-b9fa-58cad6ae5ec5.png">

401 -> reissue -> 재요청 (200) 확인하였습니다!

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->