### PR TITLE
GA, Hotjar 적용 및 유틸 개발, 적용

### DIFF
--- a/src/hooks/ga/useGaPageview.ts
+++ b/src/hooks/ga/useGaPageview.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import { gaPageview } from '~/libs/ga';
+
+export function useGaPageview() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const recordPageview = (url: string) => {
+      gaPageview(url);
+    };
+
+    router.events.on('routeChangeComplete', recordPageview);
+    return () => {
+      router.events.off('routeChangeComplete', recordPageview);
+    };
+  }, [router.events]);
+}

--- a/src/libs/ga/ga.test.ts
+++ b/src/libs/ga/ga.test.ts
@@ -1,0 +1,46 @@
+import { gaEvent, gaPageview } from './ga';
+
+describe('libs/ga', () => {
+  let windowSpy: jest.SpyInstance;
+  const gtag = jest.fn();
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+
+    windowSpy.mockImplementation(() => ({
+      gtag,
+    }));
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('should defined', () => {
+    expect(gaPageview).toBeDefined();
+    expect(gaEvent).toBeDefined();
+  });
+
+  it('gaPageview는 config, url과 함께 호출됩니다', () => {
+    const mockUrl = '/';
+
+    gaPageview(mockUrl);
+    expect(gtag).toBeCalled();
+    expect(gtag).toBeCalledWith('config', undefined, { page_path: mockUrl });
+  });
+
+  it('gaEvent는 props와 함께 event로 호출됩니다', () => {
+    const mockAction = 'action';
+    const mockCategory = 'category';
+    const mockLabel = 'label';
+    const mockValue = 'value';
+
+    gaEvent({ action: mockAction, category: mockCategory, label: mockLabel, value: mockValue });
+    expect(gtag).toBeCalled();
+    expect(gtag).toBeCalledWith('event', mockAction, {
+      event_category: mockCategory,
+      event_label: mockLabel,
+      value: mockValue,
+    });
+  });
+});

--- a/src/libs/ga/ga.ts
+++ b/src/libs/ga/ga.ts
@@ -1,0 +1,20 @@
+declare global {
+  interface Window {
+    gtag: (param1: string, param2: string | undefined, param3: object) => void;
+  }
+}
+
+export function gaPageview(url: string) {
+  window.gtag('config', process.env.NEXT_PUBLICK_GA_ID, { page_path: url });
+}
+
+interface GaEventProps {
+  action: string;
+  category?: string;
+  label?: string;
+  value?: string;
+}
+
+export function gaEvent({ category, label, value, action }: GaEventProps) {
+  window.gtag('event', action, { event_category: category, event_label: label, value });
+}

--- a/src/libs/ga/ga.ts
+++ b/src/libs/ga/ga.ts
@@ -6,7 +6,7 @@ declare global {
 
 export function gaPageview(url: string) {
   if (typeof window.gtag === 'undefined') return;
-  window.gtag('config', process.env.NEXT_PUBLICK_GA_ID, { page_path: url });
+  window.gtag('config', process.env.NEXT_PUBLIC_GA_ID, { page_path: url });
 }
 
 interface GaEventProps {

--- a/src/libs/ga/ga.ts
+++ b/src/libs/ga/ga.ts
@@ -5,6 +5,7 @@ declare global {
 }
 
 export function gaPageview(url: string) {
+  if (typeof window.gtag === 'undefined') return;
   window.gtag('config', process.env.NEXT_PUBLICK_GA_ID, { page_path: url });
 }
 
@@ -16,5 +17,6 @@ interface GaEventProps {
 }
 
 export function gaEvent({ category, label, value, action }: GaEventProps) {
+  if (typeof window.gtag === 'undefined') return;
   window.gtag('event', action, { event_category: category, event_label: label, value });
 }

--- a/src/libs/ga/ga.ts
+++ b/src/libs/ga/ga.ts
@@ -16,7 +16,7 @@ interface GaEventProps {
   value?: string;
 }
 
-export function gaEvent({ category, label, value, action }: GaEventProps) {
+export function gaEvent({ action, category, label, value }: GaEventProps) {
   if (typeof window.gtag === 'undefined') return;
   window.gtag('event', action, { event_category: category, event_label: label, value });
 }

--- a/src/libs/ga/index.test.ts
+++ b/src/libs/ga/index.test.ts
@@ -1,0 +1,9 @@
+import * as ga from './index';
+
+describe('libs/ga/index', () => {
+  it('should defined', () => {
+    expect(ga).toBeDefined();
+    expect(ga.gaPageview).toBeDefined();
+    expect(ga.gaEvent).toBeDefined();
+  });
+});

--- a/src/libs/ga/index.ts
+++ b/src/libs/ga/index.ts
@@ -1,0 +1,1 @@
+export * from './ga';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren, useEffect } from 'react';
 import { AppProps } from 'next/app';
+import NextHead from 'next/head';
 import { css, Theme, ThemeProvider } from '@emotion/react';
 import { QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -7,6 +8,7 @@ import { RecoilRoot } from 'recoil';
 
 import ToastSection from '~/components/common/ToastSection';
 import { useWindowSize } from '~/hooks/common/useWindowSize';
+import { useGaPageview } from '~/hooks/ga/useGaPageview';
 import { queryClient } from '~/libs/api/queryClient';
 import { UserProvider } from '~/store/User/UserProvider';
 import GlobalStyle from '~/styles/GlobalStyle';
@@ -14,21 +16,26 @@ import CustomTheme from '~/styles/Theme';
 import { fullViewHeight } from '~/styles/utils';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useGaPageview();
+
   return (
-    <RecoilRoot>
-      <ThemeProvider theme={CustomTheme}>
-        <QueryClientProvider client={queryClient}>
-          <GlobalStyle />
-          <UserProvider>
-            <Layout>
-              <Component {...pageProps} />
-              <ToastSection />
-            </Layout>
-          </UserProvider>
-          <ReactQueryDevtools initialIsOpen={false} />
-        </QueryClientProvider>
-      </ThemeProvider>
-    </RecoilRoot>
+    <>
+      <Head />
+      <RecoilRoot>
+        <ThemeProvider theme={CustomTheme}>
+          <QueryClientProvider client={queryClient}>
+            <GlobalStyle />
+            <UserProvider>
+              <Layout>
+                <Component {...pageProps} />
+                <ToastSection />
+              </Layout>
+            </UserProvider>
+            <ReactQueryDevtools initialIsOpen={false} />
+          </QueryClientProvider>
+        </ThemeProvider>
+      </RecoilRoot>
+    </>
   );
 }
 
@@ -58,3 +65,14 @@ const layoutCss = (theme: Theme) => css`
   margin: 0 auto;
   padding: ${theme.size.layoutPadding};
 `;
+
+function Head() {
+  return (
+    <NextHead>
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+      />
+    </NextHead>
+  );
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -25,7 +25,7 @@ export default function Document() {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', '${process.env.GA_TRACKING_ID}');
+              gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
             `,
               }}
             ></script>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,7 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
+import { IS_PRODUCTION } from '~/constants/common';
+
 export default function Document() {
   return (
     <Html>
@@ -10,26 +12,28 @@ export default function Document() {
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
         />
 
-        {/* google analytics */}
-        <script
-          async
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
-        ></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
+        {IS_PRODUCTION && (
+          <>
+            {/* google analytics */}
+            <script
+              async
+              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+            ></script>
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', '${process.env.GA_TRACKING_ID}');
             `,
-          }}
-        ></script>
+              }}
+            ></script>
 
-        {/* hotjar */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(h,o,t,j,a,r){
+            {/* hotjar */}
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `(function(h,o,t,j,a,r){
               h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
               h._hjSettings={hjid:${process.env.NEXT_PUBLIC_HOTJAR_ID},hjsv:6};
               a=o.getElementsByTagName('head')[0];
@@ -37,8 +41,10 @@ export default function Document() {
               r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
               a.appendChild(r);
           })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`,
-          }}
-        ></script>
+              }}
+            ></script>
+          </>
+        )}
       </Head>
       <body>
         <Main />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,11 +9,36 @@ export default function Document() {
           as="style"
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
         />
-        {/* NOTE: iOS input 클릭 시 Zoom In Prevent (디자이너분들과 상의 필요) */}
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
-        />
+
+        {/* google analytics */}
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+        ></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${process.env.GA_TRACKING_ID}');
+            `,
+          }}
+        ></script>
+
+        {/* hotjar */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(h,o,t,j,a,r){
+              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+              h._hjSettings={hjid:${process.env.NEXT_PUBLIC_HOTJAR_ID},hjsv:6};
+              a=o.getElementsByTagName('head')[0];
+              r=o.createElement('script');r.async=1;
+              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+              a.appendChild(r);
+          })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`,
+          }}
+        ></script>
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## ⛳️작업 내용

- `GA`를 적용했어요
- `GA`의 pageview, event 유틸을 개발했어요
- `_app`에서 next router.event를 사용해 ga pageview hook을 개발, 적용했어요
- `Hotjar`를 적용했어요
- `_document`에서 `<meta name="viewport" .../>`에서 발생하는 경고를 참고하여 `_app`에 적었어요
  - https://nextjs.org/docs/messages/no-document-viewport-meta

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

```jsx
import { gaEvent } from '~/libs/ga';

gaEvent({ action: "무슨 액션" })

gaEvent({ action: "무슨 액션", category: '카테', label: '라벨', value: '밸류' })
```

## 📎레퍼런스

- 원래 `Next/Script` 태그를 이용해 GA를 부착할려 했으나, gtag 관련 오류가 나더라구요. 그래서 이전에 적용하던 방식대로 `_document`에서 적용했어요 (https://nextjs.org/docs/messages/next-script-for-ga)

- GA ID, Hotjar ID 둘 다 결국에는 노출되어 상관없으나, 저는 환경 변수로 관리하곤 했었어요. 여러분들은 어떻게 관리하셨는 지 궁금해요!! 
> cloudflare page에 환경 변수 적용해두었어요

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
