### PR TITLE
design: iOS disabled input text color 흐려짐 방지

### DIFF
--- a/src/components/common/TextField/Input.tsx
+++ b/src/components/common/TextField/Input.tsx
@@ -78,7 +78,6 @@ export function Input({
             padding,
           }),
           ref: inputRef,
-
           ...props,
         },
         null
@@ -116,6 +115,11 @@ const inputElementCss = (
   border: 1px solid transparent;
   border-radius: ${theme.borderRadius.default};
   color: ${theme.color.gray05};
+  /* iOS에서 disabled input 텍스트 색상 자동 흐려짐 방지 */
+  /* https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios */
+  -webkit-text-fill-color: ${theme.color.gray05};
+  opacity: 1;
+  -webkit-opacity: 1;
 
   font-weight: 500;
   font-size: 14px;
@@ -128,7 +132,7 @@ const inputElementCss = (
     border-color: ${theme.color.gray03};
   }
 
-  &::placeholder {
+  &:placeholder {
     color: ${theme.color.gray03};
   }
 `;


### PR DESCRIPTION
## ⛳️작업 내용
iOS에서 disabled input의 텍스트 색상이 흐려지는 현상 방지하기 위해 아래 레퍼런스를 참고해서 css 프로퍼티를 추가합니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
![IMG_767C06451978-1](https://user-images.githubusercontent.com/69200669/169694785-9804393a-b030-43fb-a572-5f76268d5d8f.jpeg)![IMG_4C1BACC7FF3D-1](https://user-images.githubusercontent.com/69200669/169694794-2829bdcb-320c-4ae1-953d-cc75f39dd399.jpeg)

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
- https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
