### PR TITLE
next export build로 인한 dynamic routing 제거

### DIFF
--- a/src/components/add/AddTagFormRouteAsModal.tsx
+++ b/src/components/add/AddTagFormRouteAsModal.tsx
@@ -1,6 +1,7 @@
 import { css, Theme } from '@emotion/react';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
+import { MODAL_TYPE } from '~/constants/common';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import TagPage from '~/pages/add/tag';
 
@@ -10,7 +11,7 @@ export default function AddTagFormRouteAsModal() {
   const query = useQueryParam('modal', String);
 
   return (
-    <PortalWrapper isShowing={query === 'addTag'}>
+    <PortalWrapper isShowing={query === MODAL_TYPE.addTag}>
       <div css={wrapperCss}>
         <TagPage />
       </div>

--- a/src/components/home/TagFormRouteAsModal.tsx
+++ b/src/components/home/TagFormRouteAsModal.tsx
@@ -1,17 +1,19 @@
 import { css, Theme } from '@emotion/react';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
+import { MODAL_TYPE } from '~/constants/common';
 import usePreventScroll from '~/hooks/common/usePreventScroll';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import TagPage from '~/pages/tag';
 
 export default function TagFormRouteAsModal() {
   const query = useQueryParam('modal', String);
+  const isTagModal = query === MODAL_TYPE.tag;
 
-  usePreventScroll(query === 'tag');
+  usePreventScroll(isTagModal);
 
   return (
-    <PortalWrapper isShowing={query === 'tag'}>
+    <PortalWrapper isShowing={isTagModal}>
       <div css={wrapperCss}>
         <TagPage />
       </div>

--- a/src/components/home/Thumbnail.tsx
+++ b/src/components/home/Thumbnail.tsx
@@ -19,9 +19,18 @@ function Thumbnail({ id, type, tags, content, openGraph }: ContentThumbnailProps
   const { push } = useRouter();
 
   const moveToInspirationView = (id: number) => {
-    push(`?modal=inspirationView&inspirationId=${id}`, `/content/${id}`, {
-      scroll: false,
-    });
+    push(
+      {
+        query: {
+          modal: 'inspirationView',
+          id,
+        },
+      },
+      { pathname: 'content', query: { id } },
+      {
+        scroll: false,
+      }
+    );
   };
 
   return (

--- a/src/components/inspiration/InspirationViewAsModal.tsx
+++ b/src/components/inspiration/InspirationViewAsModal.tsx
@@ -3,7 +3,7 @@ import { css, Theme } from '@emotion/react';
 import PortalWrapper from '~/components/common/PortalWrapper';
 import usePreventScroll from '~/hooks/common/usePreventScroll';
 import useQueryParam from '~/hooks/common/useRouterQuery';
-import ContentPage from '~/pages/content/[inspirationId]';
+import ContentPage from '~/pages/content';
 
 export default function InspirationViewAsModal() {
   const modal = useQueryParam('modal', String);

--- a/src/components/inspiration/InspirationViewAsModal.tsx
+++ b/src/components/inspiration/InspirationViewAsModal.tsx
@@ -1,17 +1,19 @@
 import { css, Theme } from '@emotion/react';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
+import { MODAL_TYPE } from '~/constants/common';
 import usePreventScroll from '~/hooks/common/usePreventScroll';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import ContentPage from '~/pages/content';
 
 export default function InspirationViewAsModal() {
   const modal = useQueryParam('modal', String);
+  const isInspirationViewModal = modal === MODAL_TYPE.inspirationView;
 
-  usePreventScroll(modal === 'inspirationView');
+  usePreventScroll(isInspirationViewModal);
 
   return (
-    <PortalWrapper isShowing={modal === 'inspirationView'}>
+    <PortalWrapper isShowing={isInspirationViewModal}>
       <div css={wrapperCss}>
         <ContentPage />
       </div>

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -14,3 +14,9 @@ export const IS_PRODUCTION = process.env.APP_ENV === 'production';
 export const COOKIE_REFRESH = 'ygt_refresh';
 
 export const CONNECT_EMAIL = 'yeonggamt@gmail.com';
+
+export const MODAL_TYPE = {
+  addTag: 'addTag',
+  inspirationView: 'inspirationView',
+  tag: 'tag',
+};

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -14,7 +14,7 @@ import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 
 export default function ContentPage() {
-  const inspirationId = useQueryParam('inspirationId', String);
+  const inspirationId = useQueryParam('id', String);
   const { deleteInspiration } = useInspirationMutation();
   const { push } = useInternalRouter();
 


### PR DESCRIPTION
## ⛳️작업 내용
[next export build로 인한 dynamic routing 제거](https://github.com/depromeet/11th_7team_web/commit/8d82f6babac58e9bfb9446fdcc96c3d30f7bbd1c)

`content/inspirationID` route에서 새로고침을 했을 때 발생했던 404 에러가 있었어요.

원인은 결국 next export and build 방식으로 정적 빌드하는 방식 때문에 다이내믹 루트를 사용할 수 없는데,
제가 계속 그 사실을 잊고서 개발을 해버린 데에 원인이 있네요 😂 export 하는 방식을 사용하는 순간 
getServerSideProps도 넌센스인데, 이걸로 해결할 생각을 하고 있었어요.. ㅎㅎ
그래서 지금은 다이내믹 라우팅 제거하는 방식으로 해결해놓았습니다!

일단 클라우드 플레어 임시 브랜치 배포 사이트에서는 새로고침했을 때 문제 없는 것 확인했어요!
추후 머지 된 이후에 다시 한번 확인해볼게요~

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
