### PR TITLE
영감 조회 시 스크롤 복구 로직 수정

### DIFF
--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -26,7 +26,7 @@ export default function ContentPage() {
 
   useEffect(() => {
     if (isLoading) return;
-    if (!inspiration) return push('/');
+    if (!inspiration) return push('/', undefined, { scroll: false });
   }, [isLoading, inspiration, push]);
 
   const renderInspirationViewByType = useCallback((inspiration: InspirationInterface) => {


### PR DESCRIPTION
## ⛳️작업 내용

`pages/content/index.tsx` 를 주석처리해가며 처리해본 결과, 다음과 같은 순서로 실행되더라구요!

1. 네비게이션 백 버튼 클릭 (router push)
2. push 전, pages/content/index.tsx 의 useEffect 트리거 (쿼리파람을 통해 가지고온 inspiration ID가 undefined > [inspirationById, null] 키 값의 영감을 조회 > 영감이 바뀌어서 트리거됨)
3. 기존 네비게이션 백 버튼 푸시는 무마되며 useEffect의 scroll false가 없는 push가 실행

해결 방법
- useEffect의 router push에 scroll 옵션을 넣어서 해결할 수 있었어용

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
