### PR TITLE
iOS Input placeholder 색상 버그 수정

### DIFF
--- a/src/components/common/TextField/Input.tsx
+++ b/src/components/common/TextField/Input.tsx
@@ -115,8 +115,6 @@ const inputElementCss = (
   border: 1px solid transparent;
   border-radius: ${theme.borderRadius.default};
   color: ${theme.color.gray05};
-  /* iOS에서 disabled input 텍스트 색상 자동 흐려짐 방지 */
-  /* https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios */
   opacity: 1;
   -webkit-opacity: 1;
 
@@ -133,6 +131,12 @@ const inputElementCss = (
 
   &::placeholder {
     color: ${theme.color.gray03};
+  }
+
+  &:disabled {
+    /* iOS에서 disabled input 텍스트 색상 자동 흐려짐 방지 */
+    /* https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios */
+    -webkit-text-fill-color: ${theme.color.gray05};
   }
 `;
 

--- a/src/components/common/TextField/Input.tsx
+++ b/src/components/common/TextField/Input.tsx
@@ -117,7 +117,6 @@ const inputElementCss = (
   color: ${theme.color.gray05};
   /* iOS에서 disabled input 텍스트 색상 자동 흐려짐 방지 */
   /* https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios */
-  -webkit-text-fill-color: ${theme.color.gray05};
   opacity: 1;
   -webkit-opacity: 1;
 
@@ -132,7 +131,7 @@ const inputElementCss = (
     border-color: ${theme.color.gray03};
   }
 
-  &:placeholder {
+  &::placeholder {
     color: ${theme.color.gray03};
   }
 `;


### PR DESCRIPTION
## ⛳️작업 내용


- 확인해보니 파이어폭스, 크롬 환경에서는 정상적으로 동작하나 safari에서 placeholder 색이 일반 색상과 동일하게 나오더라구요.
- 가장 먼저 `:placeholder`를 `::placeholder`로 바꿔주었어요
  - 이전에는 왜 됐는지 신기....
- 이후에도 동일하게 보여주어 `-webkit-text-fill-color` 옵션을 `:disable`일 때만 적용하는 방법으로 해결했어요

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
