### PR TITLE
영감 상세 보기 애니메이션 추가 및 링크 썸네일 새 창으로 열기 추가

### DIFF
--- a/src/components/LinkThumbnail.tsx
+++ b/src/components/LinkThumbnail.tsx
@@ -39,7 +39,13 @@ export default function LinkThumbnail({
   };
 
   return (
-    <a css={linkThumbnailLinkCss} href={thumbnail.url} onClick={onOpenUrl}>
+    <a
+      css={linkThumbnailLinkCss}
+      href={thumbnail.url}
+      onClick={onOpenUrl}
+      target="_blank"
+      rel="noreferrer"
+    >
       <article css={linkThumbnailBoxCss}>
         <section css={linkThumbnailContentCss(hasImage())}>
           <p css={linkThumbnailTitleCss}>{thumbnail.title}</p>

--- a/src/components/LinkThumbnail.tsx
+++ b/src/components/LinkThumbnail.tsx
@@ -44,7 +44,7 @@ export default function LinkThumbnail({
       href={thumbnail.url}
       onClick={onOpenUrl}
       target="_blank"
-      rel="noreferrer"
+      rel="noopener noreferrer"
     >
       <article css={linkThumbnailBoxCss}>
         <section css={linkThumbnailContentCss(hasImage())}>

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { motion } from 'framer-motion';
 
 import { FilledButton, IconButton } from '~/components/common/Button';
 import IllustDialog from '~/components/common/IllustDialog';
@@ -9,6 +10,7 @@ import { FixedSpinner } from '~/components/common/Spinner';
 import ImageView from '~/components/inspiration/ImageView';
 import LinkView from '~/components/inspiration/LinkView';
 import TextView from '~/components/inspiration/TextView';
+import { defaultFadeInScaleVariants } from '~/constants/motions';
 import { useInspirationById } from '~/hooks/api/inspiration/useInspirationById';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
@@ -69,7 +71,17 @@ export default function ContentPage() {
           }
         />
         <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
-          {renderInspirationViewByType(inspiration)}
+          <motion.section
+            layout
+            layoutId="inspirationView"
+            variants={defaultFadeInScaleVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
+            {' '}
+            {renderInspirationViewByType(inspiration)}{' '}
+          </motion.section>
         </LoadingHandler>
 
         <IllustDialog

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -79,8 +79,7 @@ export default function ContentPage() {
             animate="animate"
             exit="exit"
           >
-            {' '}
-            {renderInspirationViewByType(inspiration)}{' '}
+            {renderInspirationViewByType(inspiration)}
           </motion.section>
         </LoadingHandler>
 


### PR DESCRIPTION
## ⛳️작업 내용

##  영감 상세 보기 애니메이션 추가
inspiration 상세 뷰에 motion을 적용했습니다.
`defaultFadeInScaleVariants` 요게 기본적으로 페이지마다 들어가 있는 모션으로 보여서 추가했는데, 디자이너 분들 의견도 받아보면 좋겠네요 :)

##  영감 링크 타입 클릭 시 새 탭으로 띄우기
```jsx
 <a
      css={linkThumbnailLinkCss}
      href={thumbnail.url}
      onClick={onOpenUrl}
      target="_blank"
      rel="noopener noreferrer"
    >
```
target, rel 프로퍼티를 추가했고, 배포 후 이어서 어플에서도 체크해볼게요!

### RN 확인 결과
 일단  `target="_blank"`만으로는 해결이 되지 않아서, 따로 리액트 네이티브 코드를 추가해주었어요! 그렇게 하면 앱에서도 링크 썸네일 클릭했을 때 사용자 모바일의 default browser로 새로운 창 이동이 됩니다. 