### PR TITLE
영감 memo 수정 시 focus out 될 때 저장

### DIFF
--- a/src/components/common/TextField/Input.tsx
+++ b/src/components/common/TextField/Input.tsx
@@ -42,6 +42,11 @@ export interface InputProps extends InputAndTextarea {
    * input 자동 포커스 boolean 값을 넣어 사용합니다.
    */
   autoFocus?: boolean;
+
+  /**
+   * input이 blur가 될 때 실행할 액션입니다.
+   */
+  onBlur?: VoidFunction;
 }
 
 export function Input({
@@ -51,6 +56,7 @@ export function Input({
   fixedHeight,
   padding,
   autoFocus = false,
+  onBlur,
   ...props
 }: InputProps) {
   const theme = useTheme();
@@ -78,6 +84,7 @@ export function Input({
             padding,
           }),
           ref: inputRef,
+          onBlur: onBlur,
           ...props,
         },
         null

--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useCallback, useId } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 
 import { labelCss } from '~/components/common/styles';
@@ -46,7 +46,7 @@ export interface MemoTextProps {
   /**
    * 수정(저장) 아이콘을 누르면 실행되는 함수입니다. 주입해주어야 합니다.
    */
-  onSaveClick?: () => void;
+  onSave?: () => void;
 
   /**
    * 메모 value 입니다.
@@ -71,7 +71,7 @@ export function MemoText({
   writable,
   wordLimit,
   onChange: onValueChange,
-  onSaveClick,
+  onSave,
   value,
   debouncedValue,
   autoFocus,
@@ -79,12 +79,17 @@ export function MemoText({
   const id = useId();
   const theme = useTheme();
 
-  const onClick = (
-    e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLElement, MouseEvent>
-  ) => {
-    e.preventDefault();
-    onSaveClick && onSaveClick();
-  };
+  const saveMemo = useCallback(() => {
+    onSave && onSave();
+  }, [onSave]);
+
+  const onClick = useCallback(
+    (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLElement, MouseEvent>) => {
+      e.preventDefault();
+      saveMemo();
+    },
+    [saveMemo]
+  );
 
   return (
     <TextField
@@ -117,6 +122,7 @@ export function MemoText({
       }
       disabled={!writable}
       autoFocus={autoFocus}
+      onBlur={saveMemo}
     />
   );
 }

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -44,7 +44,7 @@ export default function ImageView({ inspiration }: { inspiration: InspirationInt
             <div css={contentWrapperCss}>
               <MemoText
                 editable
-                onSaveClick={saveMemo}
+                onSave={saveMemo}
                 onChange={onMemoChange}
                 debouncedValue={memoDebouncedValue}
                 value={modifiedMemo}

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -68,7 +68,7 @@ export default function LinkView({ inspiration }: { inspiration: InspirationInte
             <div css={contentWrapperCss}>
               <MemoText
                 editable
-                onSaveClick={saveMemo}
+                onSave={saveMemo}
                 onChange={onMemoChange}
                 debouncedValue={memoDebouncedValue}
                 value={memoValue}

--- a/src/components/inspiration/TextView.tsx
+++ b/src/components/inspiration/TextView.tsx
@@ -48,7 +48,7 @@ export default function TextView({ inspiration }: { inspiration: InspirationInte
             <div css={contentWrapperCss}>
               <MemoText
                 editable
-                onSaveClick={saveMemo}
+                onSave={saveMemo}
                 onChange={memoText.onChange}
                 debouncedValue={memoText.debouncedValue}
                 value={memoText.value}


### PR DESCRIPTION
## ⛳️작업 내용
### 영감 memo 수정 시 focus out 될 때 저장
onBlur 이벤트를 추가했습니다. 펜슬 버튼을 눌러서 메모를 저장하듯이, 인풋이 블러될 때 자동 저장되면서 toast가 뜹니다.
