### PR TITLE
회원가입 시 버튼 텍스트 수정 및 회원가입 로직 리팩터링

### DIFF
--- a/src/hooks/api/auth/useSignupSendEmailMutation.ts
+++ b/src/hooks/api/auth/useSignupSendEmailMutation.ts
@@ -2,15 +2,32 @@ import { useMutation } from 'react-query';
 
 import { post } from '~/libs/api/client';
 
-export interface SignupSendEmailMutationRequest {
+export interface SignupSendEmailMutationParams {
   email: string;
+}
+
+interface UseSignupSendEmailMutationProps {
+  onSuccess?: (
+    data: any,
+    variables: SignupSendEmailMutationParams,
+    context: unknown
+  ) => void | Promise<unknown>;
+  onError?: (
+    data: { message?: string },
+    variables: SignupSendEmailMutationParams,
+    context: unknown
+  ) => void | Promise<unknown>;
 }
 
 /**
  * 회원가입을 위해 이메일에 인증 링크를 요청한다
  */
-export default function useSignupSendEmailMutation() {
-  return useMutation<undefined, { message?: string }, SignupSendEmailMutationRequest>(
-    (data: SignupSendEmailMutationRequest) => post<undefined>('/v1/auth/sends-email/signup', data)
+export default function useSignupSendEmailMutation({
+  onSuccess,
+  onError,
+}: UseSignupSendEmailMutationProps) {
+  return useMutation<undefined, { message?: string }, SignupSendEmailMutationParams>(
+    (data: SignupSendEmailMutationParams) => post<undefined>('/v1/auth/sends-email/signup', data),
+    { onSuccess, onError }
   );
 }

--- a/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
+++ b/src/hooks/api/sign-up/useCheckExistsSignupMutation.ts
@@ -11,15 +11,27 @@ export interface CheckExistsSignupMutationResponse {
   data: boolean;
 }
 
+interface UseCheckExistsSignupMutationProps {
+  onError?: (
+    data: { message?: string },
+    variables: CheckExistsSignupMutationParams,
+    context: unknown
+  ) => void | Promise<unknown>;
+}
+
 /**
  * 해당 유저가 가입되어 있는 유저인지 상태 여부를 반환한다.
  */
-export default function useCheckExistsSignupMutation() {
+export default function useCheckExistsSignupMutation({
+  onError,
+}: UseCheckExistsSignupMutationProps) {
   return useMutation<
     CheckExistsSignupMutationResponse,
     { message?: string },
     CheckExistsSignupMutationParams
-  >(({ email }: CheckExistsSignupMutationParams) =>
-    get<CheckExistsSignupMutationResponse>(`/v1/signup/${email}/status`)
+  >(
+    ({ email }: CheckExistsSignupMutationParams) =>
+      get<CheckExistsSignupMutationResponse>(`/v1/signup/${email}/status`),
+    { onError }
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -28,7 +28,11 @@ export default function Signup() {
     data: checkExistsUserData,
     error: checkExistsUserError,
     isLoading: checkExistsUserLoading,
-  } = useCheckExistsSignupMutation();
+  } = useCheckExistsSignupMutation({
+    onError: () => {
+      fireToast({ content: '유저 검사 도중 문제가 발생하였습니다.' });
+    },
+  });
 
   const handleEmailSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -102,7 +106,7 @@ export default function Signup() {
           required
         />
         <CTAButton type={'submit'} disabled={emailSendingLoading || checkExistsUserLoading}>
-          로그인
+          다음
         </CTAButton>
       </form>
       <div css={signUpTextWrapperCss}>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/router';
 import { css, Theme } from '@emotion/react';
 
@@ -17,16 +17,23 @@ export default function Signup() {
   const email = useInput({ useDebounce: true });
   const { push } = useRouter();
   const [emailError, setEmailError] = useState('');
-  const {
-    mutate: emailSendMutate,
-    error: emailSendedError,
-    isSuccess: emailSendingSuccess,
-    isLoading: emailSendingLoading,
-  } = useSignupSendEmailMutation();
+  const { mutate: emailSendMutate, isLoading: emailSendingLoading } = useSignupSendEmailMutation({
+    onSuccess: () => {
+      push({
+        pathname: '/signup/sent-email',
+        query: {
+          email: email.value,
+        },
+      });
+    },
+    onError: data => {
+      if (data.message) fireToast({ content: data.message });
+    },
+  });
+
   const {
     mutate: checkExistsUserMutate,
     data: checkExistsUserData,
-    error: checkExistsUserError,
     isLoading: checkExistsUserLoading,
   } = useCheckExistsSignupMutation({
     onError: () => {
@@ -50,40 +57,19 @@ export default function Signup() {
     }
   }, [email.debouncedValue]);
 
-  useEffect(() => {
-    if (checkExistsUserData) {
-      if (!checkExistsUserData.data) {
-        emailSendMutate({ email: email.value });
-      } else {
-        fireToast({ content: '이미 가입된 사용자입니다!' });
-      }
-    }
+  // NOTE: 이메일이 존재하지 않는 경우, 회원가입 진행 로직
+  useDidUpdate(() => {
+    if (!checkExistsUserData) return;
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!checkExistsUserData.data) {
+      emailSendMutate({ email: email.value });
+    } else {
+      fireToast({ content: '이미 가입된 사용자입니다!' });
+    }
   }, [checkExistsUserData]);
 
-  useEffect(() => {
-    if (emailSendingSuccess) {
-      push({
-        pathname: '/signup/sent-email',
-        query: {
-          email: email.value,
-        },
-      });
-    }
-  }, [email.value, emailSendingSuccess, push]);
-
-  useEffect(() => {
-    if (emailSendedError && emailSendedError.message) {
-      fireToast({ content: emailSendedError.message });
-    }
-  }, [emailSendedError, fireToast]);
-
-  useEffect(() => {
-    if (checkExistsUserError) {
-      fireToast({ content: '유저 검사 도중 문제가 발생하였습니다.' });
-    }
-  }, [checkExistsUserError, fireToast]);
+  // NOTE: 이메일 에러 메세지가 공백이 아니면서, 비동기 로직이 로딩중일 때
+  const isCTAButtonDisabled = emailError !== '' || emailSendingLoading || checkExistsUserLoading;
 
   return (
     <article css={loginCss}>
@@ -105,7 +91,7 @@ export default function Signup() {
           isSuccess={email.debouncedValue.length > 0 && emailError === ''}
           required
         />
-        <CTAButton type={'submit'} disabled={emailSendingLoading || checkExistsUserLoading}>
+        <CTAButton type={'submit'} disabled={isCTAButtonDisabled}>
           다음
         </CTAButton>
       </form>

--- a/src/pages/signup/sent-email.tsx
+++ b/src/pages/signup/sent-email.tsx
@@ -27,7 +27,7 @@ export default function SignupSentEmail() {
     error: emailSendedError,
     isSuccess: emailSendingSuccess,
     isLoading: emailSendingLoading,
-  } = useSignupSendEmailMutation();
+  } = useSignupSendEmailMutation({});
 
   const handleEmailChecking = () => {
     if (query.email !== undefined && validator({ type: 'email', value: query.email as string })) {


### PR DESCRIPTION
## ⛳️작업 내용

- `/signup`에서 로그인으로 되어 있던 버튼을 `다음` 으로 수정했어요

- framer를 확인해보니 이메일이 아닐 때도 `disabled` 상태여서 관련 로직을 추가했어요


[보이스카웃 규칙](https://johngrib.github.io/wiki/Boy-Scout-Rule/)이 눈에 밟혀 .... 몇가지 리팩토링도 해봤어요

- `useSignupSendEmailMutation`, `useCheckExistsSignupMutation`에서 effect로 관리되던 성공, 실패 로직을 useMutation의 onSuccess, onError에 위임했어요
  - 다른 훅에서 사용되는 request params 인터페이스 명과 같이 `~Request`인 것을 `~Params`로 통일시켰어요

- 몇가지 주석을 끼얹었어요



## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

저는 페이지 혹은 컴포넌트에서 로직을 `내부의 hook`으로 분리해서 추상화하는 방법을 좋아하긴 하는데,

여러분의 의견을 아직 듣지 못해서 적용해보진 않았어요 !!

예를 들자면,

```jsx
function Foo() {
  const { value, isLoading } = useFetchValue();
  
  useEffect(() => {
    로딩에따라어쩌구저쩌구;
  }, [isLoading])  

  return <div> { value } </div>
}
```

이런 컴포넌트가 있다면

```jsx
export default function Foo() {
  const { value } = useValueAtLocal();

  return <div> { value } </div>
}

export default function useValueAtLocal() {
  const { value, isLoading } = useFetchValue();
  
  useEffect(() => {
    로딩에따라어쩌구저쩌구;
  }, [isLoading])  

  return { value };
}
```

이렇게 export 시키지 않는, 내부에서만 사용하는 hook으로 추상화하는 방법으로요!

> 이런 방법으로 작성하게 되면 export되는 컴포넌트는 ui에 대한 로직만을 담고 있게 되고, 
아래 내부 hook에서 비즈니스 로직이 담게되는 모습이 돼서 저는 유지보수가 조금 더 편한 것처럼? 느껴지더라구요!

더욱 상세한 예시는 [요 컴포넌트](https://github.com/depromeet/11th_7team_web/blob/main/src/components/common/SnapCarousel/Indicator.tsx)일 거 같아요!!

**물론 적용하자는 것이 아닌 여러분의 의견이 궁금한겁니다 !! 어떻게 생각하시는 지 궁금해서 여쭤봐요 !!**