### PR TITLE
배포 대응 - 스팩 아웃 계정 삭제, 정보초기화 | 노션 링크 연결 (#295)

### DIFF
--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -46,7 +46,7 @@ export default function BottomSheetModal({ isShowing, children, onClose }: Botto
 
 const dimBackdropCss = (theme: Theme) => css`
   position: fixed;
-  z-index: 10;
+  z-index: 1000;
   top: 0;
   left: 0;
 
@@ -64,6 +64,7 @@ const contentWrapperCss = (theme: Theme) => css`
   position: absolute;
   top: 100%;
   transform: translateY(-100%);
+  z-index: 1000;
 
   width: 100%;
   min-height: ${MIN_HIEGHT}px;

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -57,7 +57,7 @@ const dimBackdropCss = (theme: Theme) => css`
 
   background-color: ${theme.color.dim03};
 
-  z-index: 10;
+  z-index: 1000;
   overflow: hidden;
 `;
 

--- a/src/components/my/Menu.tsx
+++ b/src/components/my/Menu.tsx
@@ -15,8 +15,7 @@ export interface MenuProps {
 export default function Menu({ label, rightElement, href, onClick, ...props }: MenuProps) {
   const linkRef = useRef<HTMLDivElement>(null);
 
-  const onClickHandler = (e: React.MouseEvent<HTMLSpanElement>) => {
-    if (e.target !== e.currentTarget) return;
+  const onClickHandler = () => {
     if (href) {
       linkRef.current?.click();
     } else {

--- a/src/components/my/Menu.tsx
+++ b/src/components/my/Menu.tsx
@@ -8,15 +8,24 @@ import InternalLink from '../common/InternalLink';
 export interface MenuProps {
   label: string;
   rightElement?: ReactElement;
+  /**
+   * Internal Route에 사용됩니다.
+   * ex) /my/account, '/add/tag'
+   */
   href?: RouterPathType;
+  /**
+   * 새창열기에서 사용됩니다.
+   * like) Window.open target="_blank"
+   */
+  url?: string;
   onClick?: VoidFunction;
 }
 
-export default function Menu({ label, rightElement, href, onClick, ...props }: MenuProps) {
-  const linkRef = useRef<HTMLDivElement>(null);
+export default function Menu({ label, rightElement, href, url, onClick, ...props }: MenuProps) {
+  const linkRef = useRef<HTMLAnchorElement>(null);
 
   const onClickHandler = () => {
-    if (href) {
+    if (href || url) {
       linkRef.current?.click();
     } else {
       onClick && onClick();
@@ -28,8 +37,11 @@ export default function Menu({ label, rightElement, href, onClick, ...props }: M
       <li css={MenuCss} {...props} onClick={onClickHandler}>
         {href && (
           <InternalLink href={href}>
-            <span css={hiddenCss} ref={linkRef}></span>
+            <a css={hiddenCss} ref={linkRef} />
           </InternalLink>
+        )}
+        {url && (
+          <a css={hiddenCss} href={url} ref={linkRef} target="_blank" rel="noopener noreferrer" />
         )}
         <span css={menuTitleCss}>{label}</span>
         {rightElement && <>{rightElement}</>}

--- a/src/components/my/tag/MyTagItem.tsx
+++ b/src/components/my/tag/MyTagItem.tsx
@@ -6,7 +6,8 @@ import { useToast } from '~/store/Toast';
 export default function MyTagItem({ tag }: { tag: TagType }) {
   const { deleteTag } = useTagMutation();
   const { fireToast } = useToast();
-  const onDelete = () => {
+  const onDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     deleteTag(tag.id, {
       onSuccess: () => {
         fireToast({ content: '태그 삭제 성공!' });

--- a/src/pages/my/account/index.tsx
+++ b/src/pages/my/account/index.tsx
@@ -33,13 +33,13 @@ export default function MyAccountPage() {
           <MyInformationMenu label="이메일" description={userInformation.email} />
           <Menu label="비밀번호 재설정" href="/my/account/change-password" />
         </ul>
-        <Menu
+        {/* <Menu
           label=""
           onClick={() => {
             setIsDeleteAccountModalOpen(true);
           }}
           rightElement={<span css={menuTitleCss}>계정 삭제하기</span>}
-        />
+        /> */}
       </section>
       <Dialog
         isShowing={isDeleteAccountModalOpen}
@@ -80,9 +80,9 @@ const myAccountPageCss = css`
   overflow-y: auto;
 `;
 
-const menuTitleCss = css`
-  font-size: 12px;
-`;
+// const menuTitleCss = css`
+//   font-size: 12px;
+// `;
 
 const dialogLongButtonCss = css`
   width: 163px;

--- a/src/pages/my/account/index.tsx
+++ b/src/pages/my/account/index.tsx
@@ -38,7 +38,8 @@ export default function MyAccountPage() {
           rightElement={
             <span
               css={menuTitleCss}
-              onClick={() => {
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.stopPropagation();
                 setIsDeleteAccountModalOpen(true);
               }}
             >

--- a/src/pages/my/account/index.tsx
+++ b/src/pages/my/account/index.tsx
@@ -35,17 +35,10 @@ export default function MyAccountPage() {
         </ul>
         <Menu
           label=""
-          rightElement={
-            <span
-              css={menuTitleCss}
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.stopPropagation();
-                setIsDeleteAccountModalOpen(true);
-              }}
-            >
-              계정 삭제하기
-            </span>
-          }
+          onClick={() => {
+            setIsDeleteAccountModalOpen(true);
+          }}
+          rightElement={<span css={menuTitleCss}>계정 삭제하기</span>}
         />
       </section>
       <Dialog

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -18,12 +18,13 @@ export default function MyPage() {
         <ul css={menuListCss}>
           <Menu label="내 계정" href="/my/account" />
           <Menu label="태그관리" href="/my/tag" />
-          <Menu label="이용약관" />
+          <Menu
+            label="이용약관"
+            url="https://gifted-puffin-352.notion.site/e75b7f51da7944508f37071f5345cc46"
+          />
           <Menu
             label="개인정보 정책"
-            onClick={() => {
-              console.log('이용약관');
-            }}
+            url="https://gifted-puffin-352.notion.site/94ac34de4c97467fb1f21a8bbed26eab"
           />
           {/* <Menu
             css={initializeMenuCss}

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -25,13 +25,13 @@ export default function MyPage() {
               console.log('이용약관');
             }}
           />
-          <Menu
+          {/* <Menu
             css={initializeMenuCss}
             label="정보초기화"
             onClick={() => {
               setIsInitializeConfirmModalOpen(true);
             }}
-          />
+          /> */}
         </ul>
       </section>
       <Dialog
@@ -72,9 +72,9 @@ const myPageCss = css`
   overflow-y: auto;
 `;
 
-const initializeMenuCss = css`
-  margin-top: 64px;
-`;
+// const initializeMenuCss = css`
+//   margin-top: 64px;
+// `;
 
 const dialogLongButtonCss = css`
   width: 163px;


### PR DESCRIPTION
## ⛳️작업 내용
1. `navBar`가 모달 보다 위에 존재하는 버그 해결했습니다. (z-index 설정)
2. `Menu` 추가 구현
  - rightElement event 버블링을  rightElement 이벤트 설정에서 주입하도록 변경했습니다.
  -  `Menu` url Props로 외부링크 연결할 수 있도록 코드를 추가했습니다.
  - `Menu`컴포넌트를 활용해 이용약관 개인정보 정책 외부링크 연결
3. 계정 삭제, 정보초기화 주석 처리
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/170525854-9a22b111-6074-496b-ac5d-4c931f8e1ecf.mov

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
### `Menu` 외부링크의 경우 url Props를 전달합니다.
```tsx
<Menu
  label="개인정보 정책"
  url="https://gifted-puffin-352.notion.site/94ac34de4c97467fb1f21a8bbed26eab"
/>
```

### `Menu` 내부링크의 경우 href Props를 전달합니다.
```tsx
<Menu label="태그관리" href="/my/tag" />
```

### `Menu` rightElement event 버블링 처리하기
```tsx
<Menu
  label=""
  rightElement={
    <span
      css={menuTitleCss}
      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
        e.stopPropagation();
        setIsDeleteAccountModalOpen(true);
      }}
    >
      이벤트 버블링 처리
    </span>
  }
/>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
