### PR TITLE
썸네일 크기 가변 문제 대응

### DIFF
--- a/src/components/home/Thumbnail.tsx
+++ b/src/components/home/Thumbnail.tsx
@@ -35,11 +35,13 @@ function Thumbnail({ id, type, tags, content, openGraph }: ContentThumbnailProps
 
   return (
     <motion.section css={wrapperCss} variants={contentFadeInUp} layoutId={`${id}`}>
-      <div css={contentWrapperCss} onClick={() => moveToInspirationView(id)}>
-        <ThumbnailContent type={type} content={content} openGraph={openGraph} />
-      </div>
+      <div css={supportAspectRatioWrapperCss}>
+        <div css={contentWrapperCss} onClick={() => moveToInspirationView(id)}>
+          <ThumbnailContent type={type} content={content} openGraph={openGraph} />
+        </div>
 
-      <Tags tags={tags} />
+        <Tags tags={tags} />
+      </div>
     </motion.section>
   );
 }
@@ -47,20 +49,45 @@ function Thumbnail({ id, type, tags, content, openGraph }: ContentThumbnailProps
 export default React.memo(Thumbnail);
 
 const wrapperCss = (theme: Theme) => css`
-  /* grid child width 설정 */
   max-width: 100%;
+  aspect-ratio: 1;
   overflow: hidden;
 
-  aspect-ratio: 1;
   padding: 6px;
   color: ${theme.color.background};
   background-color: ${selectRandomColor(theme, ['gray03', 'gray04', 'gray05'])};
   border-radius: ${theme.borderRadius.outer};
 
+  @supports not (aspect-ratio: 1) {
+    position: relative;
+
+    &::before {
+      content: '';
+      float: left;
+      padding-top: 100%;
+    }
+    &::after {
+      content: '';
+      display: block;
+      clear: both;
+    }
+  }
+`;
+
+const supportAspectRatioWrapperCss = css`
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   gap: 6px;
+
+  @supports not (aspect-ratio: 1) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 6px;
+  }
 `;
 
 const contentWrapperCss = (theme: Theme) => css`


### PR DESCRIPTION
## ⛳️작업 내용

홈 화면의 썸네일의 크기가 가변적으로 들어가는 문제를 해결했어요

### 원인

aspect-ratio 속성이 사파리 15버전부터 지원되어, 지원되지 않는 환경에서 발생한 것이였어요

https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#browser_compatibility

### 해결

아래 css trick과 `@supports`문을 이용해 해결했어요

https://css-tricks.com/aspect-ratio-boxes/

위 트릭

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

- [aspect-ratio 브라우저 지원 mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#browser_compatibility)
- [aspect-ratio css 트릭](https://css-tricks.com/aspect-ratio-boxes/)

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
