### PR TITLE
썸네일 aspect ratio padding 대응

### DIFF
--- a/cypress/integration/1_before_login/onboard.ts
+++ b/cypress/integration/1_before_login/onboard.ts
@@ -52,7 +52,7 @@ describe('1_before_login/onboard', () => {
   it('뒤로 간 후, 빠르게 가입하기 버튼을 누를 시 회원가입 화면으로 이동합니다.', () => {
     cy.go('back');
     cy.scrollTo('bottom', { ensureScrollable: false });
-    cy.get('button').contains('빠르게 가입하기').click();
+    cy.get('button').contains('빠르게 가입하기').should('be.visible').click();
     cy.url().should('include', '/signup');
   });
 });

--- a/src/components/home/Thumbnail.tsx
+++ b/src/components/home/Thumbnail.tsx
@@ -52,8 +52,6 @@ const wrapperCss = (theme: Theme) => css`
   max-width: 100%;
   aspect-ratio: 1;
   overflow: hidden;
-
-  padding: 6px;
   color: ${theme.color.background};
   background-color: ${selectRandomColor(theme, ['gray03', 'gray04', 'gray05'])};
   border-radius: ${theme.borderRadius.outer};
@@ -77,6 +75,7 @@ const wrapperCss = (theme: Theme) => css`
 const supportAspectRatioWrapperCss = css`
   width: 100%;
   height: 100%;
+  padding: 6px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -86,7 +85,6 @@ const supportAspectRatioWrapperCss = css`
     position: absolute;
     top: 0;
     left: 0;
-    padding: 6px;
   }
 `;
 

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -37,6 +37,8 @@ const globalCss = (theme: Theme) => css`
       word-wrap: break-word;
       -ms-overflow-style: none;
 
+      -webkit-tap-highlight-color: rgba(0, 0, 0, 0); /* iOS Button Active */
+
       -ms-overflow-style: none; /* IE 11 */
       scrollbar-width: none; /* Firefox 64 */
       ::-webkit-scrollbar {


### PR DESCRIPTION
## ⛳️작업 내용
![스크린샷 2022-05-30 오전 1 14 50](https://user-images.githubusercontent.com/26461307/170879987-94ec352d-b779-40c6-96fb-1dc83f675966.png)

위 사진처럼 iOS 환경에서 aspect ratio와 padding bottom이 동작하지 않는 이슈를 발견했어요

이를 해결하기 위해 하위 요소에 padding을 주었슴니다


>추가적으로 가끔가다 cypress 테스트 통과하지 않는 것을 해결하기 위해 should option을 추가헀어용
https://stackoverflow.com/questions/58833459/cypresserror-timed-out-retrying-cy-click-failed-because-this-element-is-deta

> iOS 환경에서 버튼을 누르고 있을 때 예상치 않게 나오는 효과를 제거했어요
https://www.notion.so/depromeet/852cda9741824a92b4c8aec241dc14c1

## 📸스크린샷

### as is

![스크린샷 2022-05-30 오전 1 18 29](https://user-images.githubusercontent.com/26461307/170880115-4b6cd090-565f-4460-91a9-d7c87774633f.png)


### to be

![스크린샷 2022-05-30 오전 1 18 58](https://user-images.githubusercontent.com/26461307/170880138-74560dbc-c7a6-40a9-a378-9eeeef0460e5.png)



## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
