### PR TITLE
설정 - 정보 초기화 API | 계정 삭제 API 적용

### DIFF
--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -47,6 +47,16 @@ export default function useInspirationMutation() {
     }
   );
 
+  const deleteAllInspirationMutation = useMutation(() => del(`/v1/inspiration/remove/all`), {
+    onSuccess: () => {
+      fireToast({ content: '정보를 초기화되었습니다!' });
+      resetInspirationList();
+    },
+    onError: (error, variable, context) => {
+      console.log('err', error, variable, context);
+    },
+  });
+
   const modifyInspirationMemoMutation = useMutation(
     (modifiedMemo: { id: number; memo: string }) => post('/v1/inspiration/modify', modifiedMemo),
     {
@@ -64,7 +74,7 @@ export default function useInspirationMutation() {
     (addTag: { id: number; tagId: number }) => post('/v1/inspiration/tag', addTag),
     {
       onSuccess: (_res, req) => {
-        fireToast({ content: '태그 추가 성공!' });
+        fireToast({ content: '태그를 추가했습니다!' });
         resetInspirationItem(req.id);
       },
       onError: (error, variable, context) => {
@@ -77,7 +87,7 @@ export default function useInspirationMutation() {
     ({ id, tagId }: { id: number; tagId: number }) => del(`/v1/inspiration/untag/${id}/${tagId}`),
     {
       onSuccess: (_res, req) => {
-        fireToast({ content: '태그 삭제 성공!' });
+        fireToast({ content: '태그를 삭제했습니다!' });
         resetInspirationItem(req.id);
       },
       onError: (error, variable, context) => {
@@ -98,6 +108,12 @@ export default function useInspirationMutation() {
      * deleteInspiration(id: number);
      */
     deleteInspiration: deleteInspirationMutation.mutate,
+
+    /**
+     * 유저의 모든 영감을 삭제합니다.
+     * deleteInspiration(id: number);
+     */
+    deleteAllInspiration: deleteAllInspirationMutation.mutate,
 
     /**
      * 영감 메모를 수정합니다.

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -16,6 +16,10 @@ export default function useInspirationMutation() {
     queryClient.resetQueries(INSPIRATION_LIST_QUERY_KEY);
   };
 
+  const removeInspirationList = () => {
+    queryClient.removeQueries(INSPIRATION_LIST_QUERY_KEY, { exact: true });
+  };
+
   const resetInspirationItem = (id: number) => {
     queryClient.invalidateQueries([INSPIRATION_BY_ID_QUERY_KEY, `${id}`]);
   };
@@ -50,7 +54,7 @@ export default function useInspirationMutation() {
   const deleteAllInspirationMutation = useMutation(() => del(`/v1/inspiration/remove/all`), {
     onSuccess: () => {
       fireToast({ content: '정보를 초기화되었습니다!' });
-      resetInspirationList();
+      removeInspirationList();
     },
     onError: (error, variable, context) => {
       console.log('err', error, variable, context);

--- a/src/hooks/api/member/useMemberSignOutMutaion.ts
+++ b/src/hooks/api/member/useMemberSignOutMutaion.ts
@@ -1,0 +1,27 @@
+import { useMutation } from 'react-query';
+
+import { COOKIE_REFRESH } from '~/constants/common';
+import useCookie from '~/hooks/common/useCookie';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { del } from '~/libs/api/client';
+import { useToast } from '~/store/Toast';
+
+export default function useMemberSiginOutMutation() {
+  const { fireToast } = useToast();
+  const { push } = useInternalRouter();
+  const { remove: cookieRemove } = useCookie();
+
+  return useMutation(() => del(`/v1/members/remove`), {
+    onSuccess: () => {
+      fireToast({ content: '계정이 삭제되었습니다!' });
+
+      //NOTE: store의 userLogout부분과 같지만 의존성 관련한 이야기에서 서로 store와 query가 서로 종속되는것을 피하며,
+      //      추후 logout로직이 달라져도, 해당 로직은 여기서 돌아가야됩니다.
+      cookieRemove(COOKIE_REFRESH);
+      push('/login');
+    },
+    onError: (error, variable, context) => {
+      console.log('err', error, variable, context);
+    },
+  });
+}

--- a/src/hooks/api/member/useMemberSignOutMutaion.ts
+++ b/src/hooks/api/member/useMemberSignOutMutaion.ts
@@ -1,24 +1,18 @@
 import { useMutation } from 'react-query';
 
-import { COOKIE_REFRESH } from '~/constants/common';
-import useCookie from '~/hooks/common/useCookie';
-import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { useUser } from '~/hooks/common/useUser';
 import { del } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
 
 export default function useMemberSiginOutMutation() {
   const { fireToast } = useToast();
-  const { push } = useInternalRouter();
-  const { remove: cookieRemove } = useCookie();
+  const { userLogout } = useUser();
 
   return useMutation(() => del(`/v1/members/remove`), {
     onSuccess: () => {
       fireToast({ content: '계정이 삭제되었습니다!' });
 
-      //NOTE: store의 userLogout부분과 같지만 의존성 관련한 이야기에서 서로 store와 query가 서로 종속되는것을 피하며,
-      //      추후 logout로직이 달라져도, 해당 로직은 여기서 돌아가야됩니다.
-      cookieRemove(COOKIE_REFRESH);
-      push('/login');
+      userLogout();
     },
     onError: (error, variable, context) => {
       console.log('err', error, variable, context);

--- a/src/pages/my/account/index.tsx
+++ b/src/pages/my/account/index.tsx
@@ -7,12 +7,14 @@ import InternalLink from '~/components/common/InternalLink';
 import NavigationBar from '~/components/common/NavigationBar';
 import MyInformationMenu from '~/components/my/InformationMenu';
 import Menu from '~/components/my/Menu';
+import useMemberSiginOutMutation from '~/hooks/api/member/useMemberSignOutMutaion';
 import { useUserInformation } from '~/store/UserInformation';
 import { fullViewHeight } from '~/styles/utils';
 
 export default function MyAccountPage() {
   const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] = useState(false);
   const { userInformation } = useUserInformation();
+  const { mutate: siginOutMutate } = useMemberSiginOutMutation();
 
   return (
     <article css={myAccountPageContainerCss}>
@@ -33,19 +35,28 @@ export default function MyAccountPage() {
           <MyInformationMenu label="이메일" description={userInformation.email} />
           <Menu label="비밀번호 재설정" internalHref="/my/account/change-password" />
         </ul>
-        {/* <Menu
+        <Menu
           label=""
           onClick={() => {
             setIsDeleteAccountModalOpen(true);
           }}
           rightElement={<span css={menuTitleCss}>계정 삭제하기</span>}
-        /> */}
+        />
       </section>
       <Dialog
         isShowing={isDeleteAccountModalOpen}
         actionButtons={
           <>
-            <FilledButton colorType="dark" onClick={() => setIsDeleteAccountModalOpen(false)}>
+            <FilledButton
+              colorType="dark"
+              onClick={() => {
+                siginOutMutate(undefined, {
+                  onSettled: () => {
+                    setIsDeleteAccountModalOpen(false);
+                  },
+                });
+              }}
+            >
               네
             </FilledButton>
             <div css={dialogLongButtonCss}>
@@ -80,9 +91,9 @@ const myAccountPageCss = css`
   overflow-y: auto;
 `;
 
-// const menuTitleCss = css`
-//   font-size: 12px;
-// `;
+const menuTitleCss = css`
+  font-size: 12px;
+`;
 
 const dialogLongButtonCss = css`
   width: 163px;

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -7,9 +7,11 @@ import NavigationBar from '~/components/common/NavigationBar';
 import Menu from '~/components/my/Menu';
 import MyProfile from '~/components/my/Profile';
 import { POLICY_URL } from '~/constants/common';
+import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 
 export default function MyPage() {
   const [isInitializeConfirmModalOpen, setIsInitializeConfirmModalOpen] = useState(false);
+  const { deleteAllInspiration } = useInspirationMutation();
 
   return (
     <article css={myPageContainerCss}>
@@ -21,20 +23,29 @@ export default function MyPage() {
           <Menu label="태그관리" internalHref="/my/tag" />
           <Menu label="이용약관" externalHref={POLICY_URL.TOS} />
           <Menu label="개인정보 정책" externalHref={POLICY_URL.PRIVACY} />
-          {/* <Menu
+          <Menu
             css={initializeMenuCss}
             label="정보초기화"
             onClick={() => {
               setIsInitializeConfirmModalOpen(true);
             }}
-          /> */}
+          />
         </ul>
       </section>
       <Dialog
         isShowing={isInitializeConfirmModalOpen}
         actionButtons={
           <>
-            <FilledButton colorType="dark" onClick={() => setIsInitializeConfirmModalOpen(false)}>
+            <FilledButton
+              colorType="dark"
+              onClick={() => {
+                deleteAllInspiration(undefined, {
+                  onSettled: () => {
+                    setIsInitializeConfirmModalOpen(false);
+                  },
+                });
+              }}
+            >
               네
             </FilledButton>
             <div css={dialogLongButtonCss}>
@@ -68,9 +79,9 @@ const myPageCss = css`
   overflow-y: auto;
 `;
 
-// const initializeMenuCss = css`
-//   margin-top: 64px;
-// `;
+const initializeMenuCss = css`
+  margin-top: 64px;
+`;
 
 const dialogLongButtonCss = css`
   width: 163px;

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -42,9 +42,8 @@ export default function SignUpEmailVerified() {
     if (!validator({ type: 'email', value: query.email as string })) {
       return fireToast({ content: '이메일이 올바르지 않습니다. 처음부터 다시 시작해주세요.' });
     }
-
     if (nicknameError !== '' || passwordError !== '' || passwordRepeatError !== '') {
-      return fireToast({ content: '모든 입력 값을 적어주세요.' });
+      return fireToast({ content: nicknameError || passwordError || passwordRepeatError });
     }
 
     if (!checkTerms && !checkPrivacy) {


### PR DESCRIPTION
## ⛳️작업 내용
- 정보 초기화 API 적용했습니다.
  - 상세는 삭제 처리되었으나 리스트에서는 계속 보여지는 오류가 발생 중입니다.
- 계정 삭제 API 적용했습니다.
- 계정 가입 - 회원정보 입력에서 오류 문구가 TOAST에 그래로 나오도록 변경했습니다.
ex) '모든 입력 값을 적어주세요.' -> '닉네임은 4자 이상 20자 이하여야 합니다.'
```ts
if (nicknameError !== '' || passwordError !== '' || passwordRepeatError !== '') {
  return fireToast({ content: '모든 입력 값을 적어주세요.' }); // as-is
  return fireToast({ content: nicknameError || passwordError || passwordRepeatError }); // to-be
}

```
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/170886027-d98d897f-e9c9-47b2-aa34-ddb42e3f7e7f.mov

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->


<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
