### PR TITLE
iOS tag delete 아이콘 색상 대응, /my/tag route 완료 버튼 동작 추가

### DIFF
--- a/src/components/common/Tag/Tag.tsx
+++ b/src/components/common/Tag/Tag.tsx
@@ -57,6 +57,7 @@ const tagCss = (theme: Theme, backGroundColor: string) => css`
 `;
 
 const closeButtonCss = css`
+  color: inherit;
   padding: 0;
   line-height: 0;
   margin-left: 4px;

--- a/src/pages/my/tag/index.tsx
+++ b/src/pages/my/tag/index.tsx
@@ -8,6 +8,7 @@ import NavigationBar from '~/components/common/NavigationBar';
 import { FixedSpinner } from '~/components/common/Spinner';
 import MyTagItem from '~/components/my/tag/MyTagItem';
 import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useIntersectionObserver from '~/hooks/common/useIntersectionObserver';
 import { fullViewHeight } from '~/styles/utils';
 
@@ -23,11 +24,21 @@ export default function MyTag() {
 
   const [isShowing, setIsShowing] = useState(false);
 
+  const router = useInternalRouter();
+
+  const onClickComplete = () => {
+    router.back();
+  };
+
   return (
     <article css={myTagCss}>
       <NavigationBar
         title="태그 관리"
-        rightElement={<GhostButton size="large">완료</GhostButton>}
+        rightElement={
+          <GhostButton size="large" onClick={onClickComplete}>
+            완료
+          </GhostButton>
+        }
       />
       <LoadingHandler
         isLoading={isLoading}


### PR DESCRIPTION
## ⛳️작업 내용

- iOS 환경에서 tag delete 버튼의 색상이 파란색으로 나오는 것을 대응했어요

- `/my/tag` route에서 완료 버튼에 뒤로 갈 수 있도록 동작을 추가했어요

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
