### PR TITLE
회원가입 페이지에서 텍스트-인풋 사이 열이 안맞는 문제

### DIFF
--- a/src/pages/password/index.tsx
+++ b/src/pages/password/index.tsx
@@ -96,7 +96,6 @@ const introCardCss = css`
 
 const introTextWrapper = (theme: Theme) => css`
   position: absolute;
-  left: 12px;
   bottom: 17px;
   color: ${theme.color.gray05};
   font-size: 15px;

--- a/src/pages/password/sent-email.tsx
+++ b/src/pages/password/sent-email.tsx
@@ -44,7 +44,6 @@ const introCardCss = css`
 
 const introTextWrapper = (theme: Theme) => css`
   position: absolute;
-  left: 12px;
   bottom: 17px;
   color: ${theme.color.gray05};
   font-size: 15px;

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -77,7 +77,6 @@ const introCardCss = css`
 
 const introTextWrapper = (theme: Theme) => css`
   position: absolute;
-  left: 12px;
   bottom: 17px;
   color: ${theme.color.gray05};
   font-size: 15px;

--- a/src/pages/signup/sent-email.tsx
+++ b/src/pages/signup/sent-email.tsx
@@ -146,7 +146,6 @@ const introCardCss = css`
 
 const introTextWrapper = (theme: Theme) => css`
   position: absolute;
-  left: 12px;
   bottom: 17px;
   color: ${theme.color.gray05};
   font-size: 15px;


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

Closed #315 

- 회원가입 페이지 인트로 메시지에 left; 12px를 제거합니다. 의도 된 것이 아니라고 합니다.
- 유사 디자인(페이지)에도 적용했습니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
