### PR TITLE
영감 추가 - 링크 타입 (패이스북 | 인스타그램 대응)

### DIFF
--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import { PlusIcon } from '~/components/common/icons';
 import { Input } from '~/components/common/TextField/Input';
 import LinkThumbnail from '~/components/LinkThumbnail';
 import { useCheckLinkAvailable } from '~/hooks/api/inspiration/useCheckLinkAvailable';
+import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { OpenGraph } from '~/pages/add/link';
@@ -20,6 +21,8 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   const { asPath } = useInternalRouter();
   const url = useInput({ useDebounce: true });
   const { openGraph: og, refetch, isFetching } = useCheckLinkAvailable({ link: url.value });
+  const [igonredOg, setigonredOg] = useState<OpenGraph | undefined>();
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
 
   const { fireToast } = useToast();
 
@@ -33,7 +36,10 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   ) => {
     e.preventDefault();
 
-    if (validator({ value: url.value, type: 'url' })) {
+    if (checkIgonreOpenGraphHost(url.value)) {
+      setigonredOg(makeURLOpenGraph(url.value));
+    } else if (validator({ value: url.value, type: 'url' })) {
+      setigonredOg(undefined);
       refetch();
     } else {
       showErrorMessage();
@@ -41,10 +47,13 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   };
 
   useEffect(() => {
+    if (igonredOg) return saveOpenGraph && saveOpenGraph(igonredOg);
+
     if (isFetching || !og) return;
     if (og.url === null) return showErrorMessage();
+
     saveOpenGraph && saveOpenGraph(og);
-  }, [isFetching, og, saveOpenGraph, showErrorMessage]);
+  }, [isFetching, og, saveOpenGraph, showErrorMessage, igonredOg]);
 
   return (
     <div css={LinkInputCss}>

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -5,7 +5,7 @@ import { PlusIcon } from '~/components/common/icons';
 import { Input } from '~/components/common/TextField/Input';
 import LinkThumbnail from '~/components/LinkThumbnail';
 import { useCheckLinkAvailable } from '~/hooks/api/inspiration/useCheckLinkAvailable';
-import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
+import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { OpenGraph } from '~/pages/add/link';
@@ -21,8 +21,8 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   const { asPath } = useInternalRouter();
   const url = useInput({ useDebounce: true });
   const { openGraph: og, refetch, isFetching } = useCheckLinkAvailable({ link: url.value });
-  const [igonredOg, setigonredOg] = useState<OpenGraph | undefined>();
-  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
+  const [ignoredOg, setIgnoredOg] = useState<OpenGraph | undefined>();
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgnoreOpenGraph();
 
   const { fireToast } = useToast();
 
@@ -37,9 +37,9 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
     e.preventDefault();
 
     if (checkIgonreOpenGraphHost(url.value)) {
-      setigonredOg(makeURLOpenGraph(url.value));
+      setIgnoredOg(makeURLOpenGraph(url.value));
     } else if (validator({ value: url.value, type: 'url' })) {
-      setigonredOg(undefined);
+      setIgnoredOg(undefined);
       refetch();
     } else {
       showErrorMessage();
@@ -47,13 +47,13 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   };
 
   useEffect(() => {
-    if (igonredOg) return saveOpenGraph && saveOpenGraph(igonredOg);
+    if (ignoredOg) return saveOpenGraph && saveOpenGraph(ignoredOg);
 
     if (isFetching || !og) return;
     if (og.url === null) return showErrorMessage();
 
     saveOpenGraph && saveOpenGraph(og);
-  }, [isFetching, og, saveOpenGraph, showErrorMessage, igonredOg]);
+  }, [isFetching, og, saveOpenGraph, showErrorMessage, ignoredOg]);
 
   return (
     <div css={LinkInputCss}>

--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -1,7 +1,7 @@
 import { SyntheticEvent, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
-import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
+import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
 import useDidMount from '~/hooks/common/useDidMount';
 import { textEllipsisCss } from '~/styles/utils';
 
@@ -71,7 +71,7 @@ function LinkContent({ openGraph, content }: Pick<ContentThumbnailProps, 'openGr
 
   const [og, setOg] = useState<OpenGraph>();
   const [src, setSrc] = useState<string>('');
-  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgnoreOpenGraph();
 
   useDidMount(() => {
     setOg(checkIgonreOpenGraphHost(content) ? makeURLOpenGraph(content) : openGraph);
@@ -92,7 +92,7 @@ function LinkContent({ openGraph, content }: Pick<ContentThumbnailProps, 'openGr
   return (
     <div css={linkWrapperCss}>
       <div css={linkImgWrapperCss}>
-        {src ? <img alt={`${og?.url} thumbnail`} src={src} onError={onImageError} /> : <></>}
+        {src && <img alt={`${og?.url} thumbnail`} src={src} onError={onImageError} />}
       </div>
 
       <div css={linkTextWrapperCss}>

--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -1,8 +1,11 @@
 import { SyntheticEvent, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
+import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
+import useDidMount from '~/hooks/common/useDidMount';
 import { textEllipsisCss } from '~/styles/utils';
 
+import { OpenGraph } from '../inspiration/LinkView';
 import { ContentThumbnailProps } from './Thumbnail';
 
 export default function ThumbnailContent({
@@ -11,7 +14,7 @@ export default function ThumbnailContent({
   openGraph,
 }: Pick<ContentThumbnailProps, 'type' | 'content' | 'openGraph'>) {
   if (type === 'IMAGE') return <img css={imageCss} alt={`${content} image`} src={content} />;
-  if (type === 'LINK') return <LinkContent openGraph={openGraph} />;
+  if (type === 'LINK') return <LinkContent openGraph={openGraph} content={content} />;
 
   // Text type
   return <p css={textCss}>{content}</p>;
@@ -31,8 +34,9 @@ const linkWrapperCss = css`
   font-size: 10px;
 `;
 
-const linkImgWrapperCss = css`
+const linkImgWrapperCss = (theme: Theme) => css`
   width: 100%;
+  background-color: ${theme.color.dim01};
 
   & > img {
     width: 100%;
@@ -61,33 +65,39 @@ const textCss = css`
   line-height: 150%;
 `;
 
-function LinkContent({ openGraph }: Pick<ContentThumbnailProps, 'openGraph'>) {
+function LinkContent({ openGraph, content }: Pick<ContentThumbnailProps, 'openGraph' | 'content'>) {
   // initial state를 og.url + og.image로 한 이유는
   // og.image가 안되는 경우가 상대주소로 작성이 되어 있어 영감탱 서버에 요청하기 때문
-  const [src, setSrc] = useState<string>(
-    openGraph && openGraph.url && openGraph.image ? openGraph.url + openGraph.image : ''
-  );
+
+  const [og, setOg] = useState<OpenGraph>();
+  const [src, setSrc] = useState<string>('');
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
+
+  useDidMount(() => {
+    setOg(checkIgonreOpenGraphHost(content) ? makeURLOpenGraph(content) : openGraph);
+    setSrc(og && og.url && og.image ? og.url + og.image : '');
+  });
 
   const onImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (!openGraph) return;
-    if (!openGraph.url) return;
-    if (!openGraph.image) return;
+    if (!og) return;
+    if (!og.url) return;
+    if (!og.image) return;
 
     // 두번째로 시도하는 og.image에서도 에러를 발생할 경우
     if (e.currentTarget.src === openGraph.image) return;
 
-    setSrc(openGraph.image);
+    setSrc(og.image);
   };
 
   return (
     <div css={linkWrapperCss}>
       <div css={linkImgWrapperCss}>
-        <img alt={`${openGraph?.url} thumbnail`} src={src} onError={onImageError} />
+        {src ? <img alt={`${og?.url} thumbnail`} src={src} onError={onImageError} /> : <></>}
       </div>
 
       <div css={linkTextWrapperCss}>
-        <p>{openGraph?.title}</p>
-        <p>{openGraph?.url}</p>
+        <p>{og?.title}</p>
+        <p>{og?.url}</p>
       </div>
     </div>
   );

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
 import LinkInput from '~/components/add/LinkInput';
 import TagContent from '~/components/common/Content/TagContent';
 import { MemoText } from '~/components/common/TextField';
+import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
 
@@ -29,6 +30,8 @@ export default function LinkView({ inspiration }: { inspiration: InspirationInte
   const { modifyInspiration } = useInspirationMutation();
   const [isWriting, setWriting] = useState(false);
 
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
+
   const saveMemo = () => {
     if (!isWriting) return setWriting(true);
     modifyInspiration({ id: inspiration.id, memo: memoValue });
@@ -36,10 +39,13 @@ export default function LinkView({ inspiration }: { inspiration: InspirationInte
   };
 
   if (!inspiration) return <></>;
-  const { tagResponses, openGraphResponse } = inspiration;
+  const { tagResponses, openGraphResponse, content } = inspiration;
 
   if (!openGraphResponse) return <></>;
-  const { description, siteName, title, url, code, image } = openGraphResponse;
+
+  const { description, siteName, title, url, code, image } = checkIgonreOpenGraphHost(content)
+    ? makeURLOpenGraph(content)
+    : openGraphResponse;
 
   return (
     <>

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import LinkInput from '~/components/add/LinkInput';
 import TagContent from '~/components/common/Content/TagContent';
 import { MemoText } from '~/components/common/TextField';
-import useIgonreOpenGrap from '~/hooks/api/inspiration/useIgonreOpenGrap';
+import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
 
@@ -30,7 +30,7 @@ export default function LinkView({ inspiration }: { inspiration: InspirationInte
   const { modifyInspiration } = useInspirationMutation();
   const [isWriting, setWriting] = useState(false);
 
-  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();
+  const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgnoreOpenGraph();
 
   const saveMemo = () => {
     if (!isWriting) return setWriting(true);

--- a/src/hooks/api/inspiration/useIgnoreOpenGraph.ts
+++ b/src/hooks/api/inspiration/useIgnoreOpenGraph.ts
@@ -6,7 +6,7 @@ const IGONRE_OPEN_GRAPH_HOSTS = [INSTAGRAM_ORIGIN, FACEBOOK_ORIGIN];
 
 const SUCCESS_CODE = 200;
 
-export default function useIgonreOpenGrap() {
+export default function useIgnoreOpenGraph() {
   const checkIgonreOpenGraphHost = (_url: string) => {
     try {
       const { host } = new URL(_url);

--- a/src/hooks/api/inspiration/useIgonreOpenGrap.ts
+++ b/src/hooks/api/inspiration/useIgonreOpenGrap.ts
@@ -1,0 +1,33 @@
+import { OpenGraph } from '~/components/inspiration/LinkView';
+
+const INSTAGRAM_ORIGIN = 'www.instagram.com';
+const FACEBOOK_ORIGIN = 'www.facebook.com';
+const IGONRE_OPEN_GRAPH_HOSTS = [INSTAGRAM_ORIGIN, FACEBOOK_ORIGIN];
+
+const SUCCESS_CODE = 200;
+
+export default function useIgonreOpenGrap() {
+  const checkIgonreOpenGraphHost = (_url: string) => {
+    try {
+      const { host } = new URL(_url);
+      return IGONRE_OPEN_GRAPH_HOSTS.includes(host);
+    } catch {
+      return false;
+    }
+  };
+  const makeURLOpenGraph = (_url: string): OpenGraph | undefined => {
+    const { origin, hostname } = new URL(_url);
+    return {
+      description: '',
+      siteName: hostname,
+      title: origin,
+      url: _url,
+      code: SUCCESS_CODE,
+    };
+  };
+
+  return {
+    checkIgonreOpenGraphHost,
+    makeURLOpenGraph,
+  };
+}


### PR DESCRIPTION
## ⛳️작업 내용
- `useIgonreOpenGrap` hooks를 생성했습니다.
  - `useIgonreOpenGrap` og 수집이 막힌 url을 검증 및 막힌 url 기반한 내부적으로 사용하는 og를 만들어내는 기능을 담고 있습니다.
- 논의 된 사항으로 og 수집이 막힌 url의 대표 URL(origin)을 title로 하는 og를 만들어내어 적용하는 방식으로 진행했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="238" alt="스크린샷 2022-06-04 오전 1 54 54" src="https://user-images.githubusercontent.com/59507527/171911558-197999b8-223a-4961-9a07-e5e66b67bc29.png">


<img width="461" alt="스크린샷 2022-06-04 오전 1 55 04" src="https://user-images.githubusercontent.com/59507527/171911567-6790db6d-ce5d-4393-ba40-8c3d91e088d1.png">


<img width="461" alt="스크린샷 2022-06-04 오전 1 55 25" src="https://user-images.githubusercontent.com/59507527/171911578-9b443a93-b7c5-4d01-893a-903a40e3e5e4.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
```ts
const url = 'https://www.instagram.com/p/CeS3123v_byLlT1/?igshid=YmM312312yMTA2M2Y='

const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgonreOpenGrap();

checkIgonreOpenGraphHost(url); // true | false
makeURLOpenGraph(url); 
/**
{
 title: 'https://www.instagram.com',
 url: 'https://www.instagram.com/p/CeS3123v_byLlT1/?igshid=YmM312312yMTA2M2Y=',
 ....
}
*/

```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
