### PR TITLE
영감 추가|편집 - 영감 태깅 플로우 변경 대응 & 태그 폼의 padding 값을 재설정

### DIFF
--- a/src/components/common/TagForm/RegisteredTagList.tsx
+++ b/src/components/common/TagForm/RegisteredTagList.tsx
@@ -35,6 +35,7 @@ export default React.memo(RegisteredTagList);
 const registeredTagsCss = css`
   display: flex;
   flex-direction: column;
+  padding: 16px 0;
   row-gap: 8px;
 `;
 

--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -65,7 +65,7 @@ export default function TagForm({
 
   return (
     <div css={formTagCss}>
-      <form onSubmit={onFormReturn}>
+      <form css={formCss} onSubmit={onFormReturn}>
         <SearchBar
           value={value}
           onChange={onChange}
@@ -75,7 +75,7 @@ export default function TagForm({
           }}
         />
       </form>
-      <AppliedTags applyedTags={applyedTags} onRemove={onRemove} />
+      {applyedTags.length ? <AppliedTags applyedTags={applyedTags} onRemove={onRemove} /> : <></>}
       <RegisteredTagList registeredTags={registeredTags} onClick={onSave} />
     </div>
   );
@@ -84,5 +84,8 @@ export default function TagForm({
 const formTagCss = css`
   display: flex;
   flex-direction: column;
-  row-gap: 16px;
+`;
+
+const formCss = css`
+  padding: 16px 0;
 `;

--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -73,6 +73,7 @@ export default function TagForm({
             setValue('');
             setKeyword('');
           }}
+          placeholder={readOnly ? '태그를 검색해보세요.' : '태그를 등록해보세요.'}
         />
       </form>
       {applyedTags.length ? <AppliedTags applyedTags={applyedTags} onRemove={onRemove} /> : <></>}

--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -76,7 +76,7 @@ export default function TagForm({
           placeholder={readOnly ? '태그를 검색해보세요.' : '태그를 등록해보세요.'}
         />
       </form>
-      {applyedTags.length ? <AppliedTags applyedTags={applyedTags} onRemove={onRemove} /> : <></>}
+      {applyedTags.length > 0 && <AppliedTags applyedTags={applyedTags} onRemove={onRemove} />}
       <RegisteredTagList registeredTags={registeredTags} onClick={onSave} />
     </div>
   );

--- a/src/components/common/TextField/SearchBar.tsx
+++ b/src/components/common/TextField/SearchBar.tsx
@@ -27,7 +27,7 @@ export function SearchBar({ value, placeholder, onRemoveClick, ...props }: Searc
           </button>
         )
       }
-      placeholder={placeholder ?? '태그를 등록 혹은 검색해보세요'}
+      placeholder={placeholder}
       padding={8}
     />
   );

--- a/src/pages/add/tag.tsx
+++ b/src/pages/add/tag.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { motion } from 'framer-motion';
 
 import LoadingHandler from '~/components/common/LoadingHandler';
@@ -12,8 +11,7 @@ import { useAppliedTags } from '~/store/AppliedTags';
 
 export default function TagPage() {
   const { tags: appliedTags, removeTag, addTag } = useAppliedTags();
-  const [keyword, setKeyword] = useState('');
-  const { tags, isLoading, hasNextPage, fetchNextPage } = useGetTagListWithInfinite({ keyword });
+  const { tags, isLoading, hasNextPage, fetchNextPage } = useGetTagListWithInfinite({});
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: ([{ isIntersecting }]) => {
@@ -37,9 +35,6 @@ export default function TagPage() {
             registeredTags={tags}
             onSave={addTag}
             onRemove={removeTag}
-            onSearch={keyword => {
-              setKeyword(keyword);
-            }}
           />
           {hasNextPage && !isLoading && <div ref={setTarget}></div>}
         </motion.div>

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
@@ -22,8 +22,7 @@ export default function EditTag() {
   const { inspiration } = useInspirationById({
     inspirationId,
   });
-  const [keyword, setKeyword] = useState('');
-  const { tags, isLoading, hasNextPage, fetchNextPage } = useGetTagListWithInfinite({ keyword });
+  const { tags, isLoading, hasNextPage, fetchNextPage } = useGetTagListWithInfinite({});
   const { addInspirationTag, deleteInspirationTag } = useInspirationMutation();
 
   const { setTarget } = useIntersectionObserver({
@@ -67,9 +66,6 @@ export default function EditTag() {
             registeredTags={tags}
             onSave={saveTag}
             onRemove={removeTag}
-            onSearch={keyword => {
-              setKeyword(keyword);
-            }}
           />
           {hasNextPage && !isLoading && <div ref={setTarget}></div>}
         </motion.div>


### PR DESCRIPTION
## ⛳️작업 내용
- 영감 추가 및 편집 - 영감 태깅에서 검색 로직 제거했습니다.
  - onSearch, keyword 등을 삭제 하였습니다.
- 태그 폼의 padding 값을 재설정 해주었습니다.
논의에 따른 적용 내용
```
-기존안 최대한 유지-
태그 필터에서는 검색만, 태그 추가에서는 추가만 (기존 리스트는 제공, 검색불가능)
```
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<img width="461" alt="image" src="https://user-images.githubusercontent.com/59507527/171933822-d3eee8b1-8dd5-417b-a39d-a46d924d05e2.png">



<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
