### PR TITLE
닉네임 변경 로직 보수

### DIFF
--- a/src/pages/my/account/change-nickname.tsx
+++ b/src/pages/my/account/change-nickname.tsx
@@ -13,12 +13,14 @@ import NavigationBar from '../../../components/common/NavigationBar';
 import TextField from '../../../components/common/TextField';
 
 export default function MyAccountChangeNickame() {
-  const nickname = useInput({ useDebounce: true });
+  const { userInformation } = useUserInformation();
+  const nickname = useInput({ useDebounce: true, initialValue: userInformation.nickName });
   const [nicknameError, setNicknameError] = useState('');
   const { callMuation, onFormReturn, isValidateNickname } = useChangeNickname({
     nickname,
     nicknameError,
     setNicknameError,
+    userInformation,
   });
 
   return (
@@ -64,15 +66,20 @@ interface UseChangeNicknameProps {
   nickname: ReturnType<typeof useInput>;
   nicknameError: string;
   setNicknameError: Dispatch<SetStateAction<string>>;
+  userInformation: UserInformationType;
 }
 
-function useChangeNickname({ nickname, nicknameError, setNicknameError }: UseChangeNicknameProps) {
+function useChangeNickname({
+  nickname,
+  nicknameError,
+  setNicknameError,
+  userInformation,
+}: UseChangeNicknameProps) {
   const { fireToast } = useToast();
-  const { userInformation } = useUserInformation();
   const { updateNickname } = useUserInformationMutation();
   const { push } = useInternalRouter();
 
-  // NOTE: 변경 전 닉네임 setStating
+  // NOTE: route 직접 방문 시 변경 전 닉네임 setStating
   useDidUpdate(() => {
     nickname.setValue(userInformation.nickName);
   }, [userInformation.nickName]);

--- a/src/pages/my/account/change-nickname.tsx
+++ b/src/pages/my/account/change-nickname.tsx
@@ -78,9 +78,9 @@ function useChangeNickname({ nickname, nicknameError, setNicknameError }: UseCha
   }, [userInformation.nickName]);
 
   const isNicknameNotValidateForLength =
-    nickname.debouncedValue.length < 4 || 20 < nickname.debouncedValue.length;
+    nickname.debouncedValue.trim().length < 4 || 20 < nickname.debouncedValue.trim().length;
 
-  const isNicknameSameWithPrev = userInformation.nickName === nickname.debouncedValue;
+  const isNicknameSameWithPrev = userInformation.nickName === nickname.debouncedValue.trim();
 
   const isValidateNickname = !isNicknameNotValidateForLength && !isNicknameSameWithPrev;
 
@@ -101,7 +101,7 @@ function useChangeNickname({ nickname, nicknameError, setNicknameError }: UseCha
     if (nicknameError) return fireToast({ content: nicknameError });
 
     updateNickname(
-      { nickname: nickname.debouncedValue },
+      { nickname: nickname.debouncedValue.trim() },
       {
         onSuccess: () => {
           push('/my/account');

--- a/src/pages/my/account/change-nickname.tsx
+++ b/src/pages/my/account/change-nickname.tsx
@@ -15,7 +15,7 @@ import TextField from '../../../components/common/TextField';
 export default function MyAccountChangeNickame() {
   const { userInformation } = useUserInformation();
   const nickname = useInput({ useDebounce: true, initialValue: userInformation.nickName });
-  const [nicknameError, setNicknameError] = useState('');
+  const [nicknameError, setNicknameError] = useState('변경될 이름을 입력해주세요.');
   const { callMuation, onFormReturn, isValidateNickname } = useChangeNickname({
     nickname,
     nicknameError,
@@ -91,16 +91,12 @@ function useChangeNickname({
 
   const isValidateNickname = !isNicknameNotValidateForLength && !isNicknameSameWithPrev;
 
-  console.log('userInformation: ' + userInformation.nickName);
-  console.log('nickname debounced: ' + nickname.debouncedValue.trim());
-
   useDidUpdate(() => {
-    console.log('isNicknameSameWithPrev: ' + isNicknameSameWithPrev);
-
     if (isNicknameNotValidateForLength) {
       setNicknameError('닉네임은 4자 이상 20자 이하여야 합니다.');
       return;
     }
+
     if (isNicknameSameWithPrev) {
       setNicknameError('변경될 이름을 입력해주세요.');
       return;

--- a/src/pages/my/account/change-nickname.tsx
+++ b/src/pages/my/account/change-nickname.tsx
@@ -91,7 +91,12 @@ function useChangeNickname({
 
   const isValidateNickname = !isNicknameNotValidateForLength && !isNicknameSameWithPrev;
 
+  console.log('userInformation: ' + userInformation.nickName);
+  console.log('nickname debounced: ' + nickname.debouncedValue.trim());
+
   useDidUpdate(() => {
+    console.log('isNicknameSameWithPrev: ' + isNicknameSameWithPrev);
+
     if (isNicknameNotValidateForLength) {
       setNicknameError('닉네임은 4자 이상 20자 이하여야 합니다.');
       return;

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -52,14 +52,14 @@ export default function SignUpEmailVerified() {
 
     signupMutate({
       email: query.email as string,
-      nickName: nickname.value,
+      nickName: nickname.value.trim(),
       password: password.value,
       confirmPassword: passwordRepeat.value,
     });
   };
 
   useDidUpdate(() => {
-    if (nickname.debouncedValue.length >= 4 && nickname.debouncedValue.length <= 20) {
+    if (nickname.debouncedValue.trim().length >= 4 && nickname.debouncedValue.trim().length <= 20) {
       setNicknameError('');
     } else {
       setNicknameError('닉네임은 4자 이상 20자 이하여야 합니다.');

--- a/src/store/UserInformation/useUserInformation.ts
+++ b/src/store/UserInformation/useUserInformation.ts
@@ -8,7 +8,6 @@ export function useUserInformation() {
   const [userInformation, setUserInformation] = useRecoilState(userInformationState);
   useGetUserInformation(setUserInformation);
 
-  console.log(userInformation.nickName);
   return {
     userInformation,
     setUserInformation,

--- a/src/store/UserInformation/useUserInformation.ts
+++ b/src/store/UserInformation/useUserInformation.ts
@@ -8,6 +8,7 @@ export function useUserInformation() {
   const [userInformation, setUserInformation] = useRecoilState(userInformationState);
   useGetUserInformation(setUserInformation);
 
+  console.log(userInformation.nickName);
   return {
     userInformation,
     setUserInformation,


### PR DESCRIPTION
## ⛳️작업 내용

- 닉네임 변경 시 검증, mutation에 trim된 값을 사용하도록 수정했어요

- 회원가입도 동일하게 trim된 값을 사용하도록 수정했어요

- 프로덕션 환경에서 `/my/account` -> `/my/account/change-nickname`으로 이동할 시 `userInformation`이 empty된 문제 해결중
  - 직접 `/my/account/change-nickname`으로 접속할 시 이상없음
  -> `useChangeNickname/useDidUpdate`의 의존성이 `userInformation.nickname`이 걸려있는데
  이전에 방문한, 즉 이미 캐싱된 값은 userInformation에서 달라지지 않아 발생한 문제
  -> useInput의 initialValue를 사용하여 해결

- 프로덕션 환경에서 `/my/account/change-nickname`의 초기 에러메시지(동일할 때)가 등장하지 않음
  - `useDidUpdate`의 의존성이 nickname.debouncedValue가 걸려있어 트리거되지 않는 것이였음
  -> 처음 방문할 시에는 항상 같은 닉네임이니 초기값으로 설정하여 해결

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
